### PR TITLE
Apply current unit tests to torchless package

### DIFF
--- a/test/package/common.py
+++ b/test/package/common.py
@@ -29,6 +29,7 @@ class PackageTestCase(TestCase):
         self.package_test_dir = os.path.dirname(os.path.realpath(__file__))
         self.orig_sys_path = sys.path.copy()
         sys.path.append(self.package_test_dir)
+        package.package_exporter._gate_torchscript_serialization = False
 
     def tearDown(self):
         super().tearDown()

--- a/test/package/generate_bc_packages.py
+++ b/test/package/generate_bc_packages.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import package
 import torch
 from package import PackageExporter
 from torch.fx import symbolic_trace

--- a/test/package/package_a/use_torch_package_importer.py
+++ b/test/package/package_a/use_torch_package_importer.py
@@ -1,4 +1,4 @@
 try:
-    import torch_package_importer  # noqa: F401 @manual
+    import torch_package_importer  # noqa: F401
 except ImportError:
     pass

--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -6,8 +6,19 @@ from sys import version_info
 from textwrap import dedent
 from unittest import skipIf
 
-from package import EmptyMatchError, Importer, PackageExporter, PackageImporter
-from package.package_exporter_no_torch import PackagingError
+from package import (
+    EmptyMatchError,
+    Importer,
+    PackageExporter,
+    PackageImporter,
+    PackagingError,
+)
+from package.package_exporter_no_torch import (
+    PackageExporter as PackageExporterNoTorch,
+)
+from package.package_importer_no_torch import (
+    PackageImporter as PackageImporterNoTorch,
+)
 from torch.testing._internal.common_utils import IS_WINDOWS, run_tests
 
 try:
@@ -24,13 +35,18 @@ class TestDependencyAPI(PackageTestCase):
     - deny()
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporter
+        self.PackageExporter = PackageExporter
+
     def test_extern(self):
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             he.extern(["package_a.subpackage", "module_a"])
             he.save_source_string("foo", "import package_a.subpackage; import module_a")
         buffer.seek(0)
-        hi = PackageImporter(buffer)
+        hi = self.PackageImporter(buffer)
         import module_a
         import package_a.subpackage
 
@@ -44,7 +60,7 @@ class TestDependencyAPI(PackageTestCase):
 
     def test_extern_glob(self):
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             he.extern(["package_a.*", "module_*"])
             he.save_module("package_a")
             he.save_source_string(
@@ -57,7 +73,7 @@ class TestDependencyAPI(PackageTestCase):
                 ),
             )
         buffer.seek(0)
-        hi = PackageImporter(buffer)
+        hi = self.PackageImporter(buffer)
         import module_a
         import package_a.subpackage
 
@@ -78,7 +94,7 @@ class TestDependencyAPI(PackageTestCase):
 
         buffer = BytesIO()
         with self.assertRaisesRegex(EmptyMatchError, r"did not match any modules"):
-            with PackageExporter(buffer) as exporter:
+            with self.PackageExporter(buffer) as exporter:
                 exporter.extern(include=["package_b.*"], allow_empty=False)
                 exporter.save_module("package_a.subpackage")
 
@@ -89,7 +105,7 @@ class TestDependencyAPI(PackageTestCase):
         buffer = BytesIO()
 
         with self.assertRaisesRegex(PackagingError, "denied"):
-            with PackageExporter(buffer) as exporter:
+            with self.PackageExporter(buffer) as exporter:
                 exporter.deny(["package_a.subpackage", "module_a"])
                 exporter.save_source_string("foo", "import package_a.subpackage")
 
@@ -99,7 +115,7 @@ class TestDependencyAPI(PackageTestCase):
         """
         buffer = BytesIO()
         with self.assertRaises(PackagingError):
-            with PackageExporter(buffer) as exporter:
+            with self.PackageExporter(buffer) as exporter:
                 exporter.deny(["package_a.*", "module_*"])
                 exporter.save_source_string(
                     "test_module",
@@ -114,12 +130,12 @@ class TestDependencyAPI(PackageTestCase):
     @skipIf(version_info < (3, 7), "mock uses __getattr__ a 3.7 feature")
     def test_mock(self):
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             he.mock(["package_a.subpackage", "module_a"])
             # Import something that dependso n package_a.subpackage
             he.save_source_string("foo", "import package_a.subpackage")
         buffer.seek(0)
-        hi = PackageImporter(buffer)
+        hi = self.PackageImporter(buffer)
         import package_a.subpackage
 
         _ = package_a.subpackage
@@ -135,7 +151,7 @@ class TestDependencyAPI(PackageTestCase):
     @skipIf(version_info < (3, 7), "mock uses __getattr__ a 3.7 feature")
     def test_mock_glob(self):
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             he.mock(["package_a.*", "module*"])
             he.save_module("package_a")
             he.save_source_string(
@@ -148,7 +164,7 @@ class TestDependencyAPI(PackageTestCase):
                 ),
             )
         buffer.seek(0)
-        hi = PackageImporter(buffer)
+        hi = self.PackageImporter(buffer)
         import package_a.subpackage
 
         _ = package_a.subpackage
@@ -170,7 +186,7 @@ class TestDependencyAPI(PackageTestCase):
 
         buffer = BytesIO()
         with self.assertRaisesRegex(EmptyMatchError, r"did not match any modules"):
-            with PackageExporter(buffer) as exporter:
+            with self.PackageExporter(buffer) as exporter:
                 exporter.mock(include=["package_b.*"], allow_empty=False)
                 exporter.save_module("package_a.subpackage")
 
@@ -183,7 +199,7 @@ class TestDependencyAPI(PackageTestCase):
 
         buffer = BytesIO()
         with self.assertRaises(PackagingError):
-            with PackageExporter(buffer) as he:
+            with self.PackageExporter(buffer) as he:
                 he.mock(include="package_a.subpackage")
                 he.intern("**")
                 he.save_pickle("obj", "obj.pkl", obj2)
@@ -196,7 +212,7 @@ class TestDependencyAPI(PackageTestCase):
         obj2 = package_a.PackageAObject(obj)
 
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             he.intern(include="package_a.**")
             he.mock("**")
             he.save_pickle("obj", "obj.pkl", obj2)
@@ -205,7 +221,7 @@ class TestDependencyAPI(PackageTestCase):
         """If an error occurs during packaging, it should not be shadowed by the allow_empty error."""
         buffer = BytesIO()
         with self.assertRaises(ModuleNotFoundError):
-            with PackageExporter(buffer) as pe:
+            with self.PackageExporter(buffer) as pe:
                 # Even though we did not extern a module that matches this
                 # pattern, we want to show the save_module error, not the allow_empty error.
 
@@ -222,7 +238,7 @@ class TestDependencyAPI(PackageTestCase):
         import package_a  # noqa: F401
 
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             he.save_module("package_a")
 
     def test_intern_error(self):
@@ -235,7 +251,7 @@ class TestDependencyAPI(PackageTestCase):
         buffer = BytesIO()
 
         with self.assertRaises(PackagingError) as e:
-            with PackageExporter(buffer) as he:
+            with self.PackageExporter(buffer) as he:
                 he.save_pickle("obj", "obj.pkl", obj2)
 
         self.assertEqual(
@@ -250,7 +266,7 @@ class TestDependencyAPI(PackageTestCase):
         )
 
         # Interning all dependencies should work
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             he.intern(["package_a", "package_a.subpackage"])
             he.save_pickle("obj", "obj.pkl", obj2)
 
@@ -281,7 +297,7 @@ class TestDependencyAPI(PackageTestCase):
         buffer = BytesIO()
 
         with self.assertRaises(PackagingError) as e:
-            with PackageExporter(buffer, importer=BrokenImporter()) as exporter:
+            with self.PackageExporter(buffer, importer=BrokenImporter()) as exporter:
                 exporter.intern(["foo", "bar"])
                 exporter.save_source_string("my_module", "import foo; import bar")
 
@@ -300,7 +316,7 @@ class TestDependencyAPI(PackageTestCase):
         """An incorrectly-formed import should raise a PackagingError."""
         buffer = BytesIO()
         with self.assertRaises(PackagingError) as e:
-            with PackageExporter(buffer) as exporter:
+            with self.PackageExporter(buffer) as exporter:
                 # This import will fail to load.
                 exporter.save_source_string("foo", "from ........ import lol")
 
@@ -319,12 +335,12 @@ class TestDependencyAPI(PackageTestCase):
     def test_repackage_mocked_module(self):
         """Re-packaging a package that contains a mocked module should work correctly."""
         buffer = BytesIO()
-        with PackageExporter(buffer) as exporter:
+        with self.PackageExporter(buffer) as exporter:
             exporter.mock("package_a")
             exporter.save_source_string("foo", "import package_a")
 
         buffer.seek(0)
-        importer = PackageImporter(buffer)
+        importer = self.PackageImporter(buffer)
         foo = importer.import_module("foo")
 
         # "package_a" should be mocked out.
@@ -334,18 +350,25 @@ class TestDependencyAPI(PackageTestCase):
         # Re-package the model, but intern the previously-mocked module and mock
         # everything else.
         buffer2 = BytesIO()
-        with PackageExporter(buffer2, importer=importer) as exporter:
+        with self.PackageExporter(buffer2, importer=importer) as exporter:
             exporter.intern("package_a")
             exporter.mock("**")
             exporter.save_source_string("foo", "import package_a")
 
         buffer2.seek(0)
-        importer2 = PackageImporter(buffer2)
+        importer2 = self.PackageImporter(buffer2)
         foo2 = importer2.import_module("foo")
 
         # "package_a" should still be mocked out.
         with self.assertRaises(NotImplementedError):
             foo2.package_a.get_something()
+
+
+class TestDependencyAPINoTorch(TestDependencyAPI):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporterNoTorch
+        self.PackageExporter = PackageExporterNoTorch
 
 
 if __name__ == "__main__":

--- a/test/package/test_dependency_hooks.py
+++ b/test/package/test_dependency_hooks.py
@@ -5,6 +5,9 @@ from io import BytesIO
 from package import (
     PackageExporter,
 )
+from package.package_exporter_no_torch import (
+    PackageExporter as PackageExporterNoTorch,
+)
 from torch.testing._internal.common_utils import run_tests
 
 try:
@@ -20,6 +23,10 @@ class TestDependencyHooks(PackageTestCase):
     - register_extern_hook()
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageExporter = PackageExporter
+
     def test_single_hook(self):
         buffer = BytesIO()
 
@@ -28,7 +35,7 @@ class TestDependencyHooks(PackageTestCase):
         def my_extern_hook(package_exporter, module_name):
             my_externs.add(module_name)
 
-        with PackageExporter(buffer) as exporter:
+        with self.PackageExporter(buffer) as exporter:
             exporter.extern(["package_a.subpackage", "module_a"])
             exporter.register_extern_hook(my_extern_hook)
             exporter.save_source_string("foo", "import module_a")
@@ -47,7 +54,7 @@ class TestDependencyHooks(PackageTestCase):
         def my_extern_hook2(package_exporter, module_name):
             my_externs.remove(module_name)
 
-        with PackageExporter(buffer) as exporter:
+        with self.PackageExporter(buffer) as exporter:
             exporter.extern(["package_a.subpackage", "module_a"])
             exporter.register_extern_hook(my_extern_hook)
             exporter.register_extern_hook(my_extern_hook2)
@@ -67,7 +74,7 @@ class TestDependencyHooks(PackageTestCase):
         def my_mock_hook2(package_exporter, module_name):
             my_mocks.remove(module_name)
 
-        with PackageExporter(buffer) as exporter:
+        with self.PackageExporter(buffer) as exporter:
             exporter.mock(["package_a.subpackage", "module_a"])
             exporter.register_mock_hook(my_mock_hook)
             exporter.register_mock_hook(my_mock_hook2)
@@ -87,7 +94,7 @@ class TestDependencyHooks(PackageTestCase):
         def my_extern_hook2(package_exporter, module_name):
             my_externs2.add(module_name)
 
-        with PackageExporter(buffer) as exporter:
+        with self.PackageExporter(buffer) as exporter:
             exporter.extern(["package_a.subpackage", "module_a"])
             handle = exporter.register_extern_hook(my_extern_hook)
             exporter.register_extern_hook(my_extern_hook2)
@@ -109,7 +116,7 @@ class TestDependencyHooks(PackageTestCase):
         def my_mock_hook(package_exporter, module_name):
             my_mocks.add(module_name)
 
-        with PackageExporter(buffer) as exporter:
+        with self.PackageExporter(buffer) as exporter:
             exporter.extern("module_a")
             exporter.mock("package_a")
             exporter.register_extern_hook(my_extern_hook)
@@ -118,6 +125,12 @@ class TestDependencyHooks(PackageTestCase):
 
         self.assertEqual(my_externs, set(["module_a"]))
         self.assertEqual(my_mocks, set(["package_a"]))
+
+
+class TestDependencyHooksNoTorch(TestDependencyHooks):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageExporter = PackageExporterNoTorch
 
 
 if __name__ == "__main__":

--- a/test/package/test_digraph.py
+++ b/test/package/test_digraph.py
@@ -116,7 +116,7 @@ class TestDiGraph(PackageTestCase):
 
         result = g.all_paths("1", "3")
         # to get rid of indeterminism
-        actual = set([i.strip("\n") for i in result.split(";")[2:-1]])
+        actual = {i.strip("\n") for i in result.split(";")[2:-1]}
         expected = {
             '"2" -> "3"',
             '"1" -> "7"',

--- a/test/package/test_directory_reader.py
+++ b/test/package/test_directory_reader.py
@@ -10,6 +10,12 @@ from unittest import skipIf
 
 import torch
 from package import PackageExporter, PackageImporter
+from package.package_exporter_no_torch import (
+    PackageExporter as PackageExporterNoTorch,
+)
+from package.package_importer_no_torch import (
+    PackageImporter as PackageImporterNoTorch,
+)
 from torch.testing._internal.common_utils import (
     run_tests,
     IS_FBCODE,
@@ -44,6 +50,11 @@ packaging_directory = Path(__file__).parent
 class DirectoryReaderTest(PackageTestCase):
     """Tests use of DirectoryReader as accessor for opened packages."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageExporter = PackageExporter
+        self.PackageImporter = PackageImporter
+
     @skipIfNoTorchVision
     def test_loading_pickle(self):
         """
@@ -52,7 +63,7 @@ class DirectoryReaderTest(PackageTestCase):
         resnet = resnet18()
 
         filename = self.temp()
-        with PackageExporter(filename) as e:
+        with self.PackageExporter(filename) as e:
             e.intern("**")
             e.save_pickle("model", "model.pkl", resnet)
 
@@ -60,7 +71,7 @@ class DirectoryReaderTest(PackageTestCase):
 
         with TemporaryDirectory() as temp_dir:
             zip_file.extractall(path=temp_dir)
-            importer = PackageImporter(Path(temp_dir) / Path(filename).name)
+            importer = self.PackageImporter(Path(temp_dir) / Path(filename).name)
             dir_mod = importer.load_pickle("model", "model.pkl")
             input = torch.rand(1, 3, 224, 224)
             self.assertEqual(dir_mod(input), resnet(input))
@@ -72,14 +83,14 @@ class DirectoryReaderTest(PackageTestCase):
         import package_a
 
         filename = self.temp()
-        with PackageExporter(filename) as e:
+        with self.PackageExporter(filename) as e:
             e.save_module("package_a")
 
         zip_file = zipfile.ZipFile(filename, "r")
 
         with TemporaryDirectory() as temp_dir:
             zip_file.extractall(path=temp_dir)
-            dir_importer = PackageImporter(Path(temp_dir) / Path(filename).name)
+            dir_importer = self.PackageImporter(Path(temp_dir) / Path(filename).name)
             dir_mod = dir_importer.import_module("package_a")
             self.assertEqual(dir_mod.result, package_a.result)
 
@@ -90,22 +101,25 @@ class DirectoryReaderTest(PackageTestCase):
         import package_a  # noqa: F401
 
         filename = self.temp()
-        with PackageExporter(filename) as e:
+        print(f"filename is {filename}")
+        with self.PackageExporter(filename) as e:
             e.save_module("package_a")
 
         zip_file = zipfile.ZipFile(filename, "r")
 
         with TemporaryDirectory() as temp_dir:
+            print("temp dir is ", temp_dir)
+            print("searching for ", Path(temp_dir) / Path(filename).name)
             zip_file.extractall(path=temp_dir)
-            dir_importer = PackageImporter(Path(temp_dir) / Path(filename).name)
-            self.assertTrue(dir_importer.zip_reader.has_record("package_a/__init__.py"))
-            self.assertFalse(dir_importer.zip_reader.has_record("package_a"))
+            dir_importer = self.PackageImporter(Path(temp_dir) / Path(filename).name)
+            self.assertTrue(dir_importer.zip_file.has_record("package_a/__init__.py"))
+            self.assertFalse(dir_importer.zip_file.has_record("package_a"))
 
     @skipIf(version_info < (3, 7), "ResourceReader API introduced in Python 3.7")
     def test_resource_reader(self):
         """Tests DirectoryReader as the base for get_resource_reader."""
         filename = self.temp()
-        with PackageExporter(filename) as pe:
+        with self.PackageExporter(filename) as pe:
             # Layout looks like:
             #    package
             #    ├── one/
@@ -132,7 +146,7 @@ class DirectoryReaderTest(PackageTestCase):
 
         with TemporaryDirectory() as temp_dir:
             zip_file.extractall(path=temp_dir)
-            importer = PackageImporter(Path(temp_dir) / Path(filename).name)
+            importer = self.PackageImporter(Path(temp_dir) / Path(filename).name)
             reader_one = importer.get_resource_reader("one")
 
             # Different behavior from still zipped archives
@@ -187,7 +201,7 @@ class DirectoryReaderTest(PackageTestCase):
             """
         )
         filename = self.temp()
-        with PackageExporter(filename) as pe:
+        with self.PackageExporter(filename) as pe:
             pe.save_source_string("foo.bar", mod_src)
             pe.save_text("my_cool_resources", "sekrit.txt", "my sekrit plays")
 
@@ -195,7 +209,7 @@ class DirectoryReaderTest(PackageTestCase):
 
         with TemporaryDirectory() as temp_dir:
             zip_file.extractall(path=temp_dir)
-            dir_importer = PackageImporter(Path(temp_dir) / Path(filename).name)
+            dir_importer = self.PackageImporter(Path(temp_dir) / Path(filename).name)
             self.assertEqual(
                 dir_importer.import_module("foo.bar").secret_message(),
                 "my sekrit plays",
@@ -204,7 +218,7 @@ class DirectoryReaderTest(PackageTestCase):
     @skipIf(version_info < (3, 7), "ResourceReader API introduced in Python 3.7")
     def test_importer_access(self):
         filename = self.temp()
-        with PackageExporter(filename) as he:
+        with self.PackageExporter(filename) as he:
             he.save_text("main", "main", "my string")
             he.save_binary("main", "main_binary", "my string".encode("utf-8"))
             src = dedent(
@@ -222,7 +236,7 @@ class DirectoryReaderTest(PackageTestCase):
 
         with TemporaryDirectory() as temp_dir:
             zip_file.extractall(path=temp_dir)
-            dir_importer = PackageImporter(Path(temp_dir) / Path(filename).name)
+            dir_importer = self.PackageImporter(Path(temp_dir) / Path(filename).name)
             m = dir_importer.import_module("main")
             self.assertEqual(m.t, "my string")
             self.assertEqual(m.b, "my string".encode("utf-8"))
@@ -233,7 +247,7 @@ class DirectoryReaderTest(PackageTestCase):
         Tests that packaged code can used importlib.resources.path.
         """
         filename = self.temp()
-        with PackageExporter(filename) as e:
+        with self.PackageExporter(filename) as e:
             e.save_binary("string_module", "my_string", "my string".encode("utf-8"))
             src = dedent(
                 """\
@@ -251,7 +265,7 @@ class DirectoryReaderTest(PackageTestCase):
 
         with TemporaryDirectory() as temp_dir:
             zip_file.extractall(path=temp_dir)
-            dir_importer = PackageImporter(Path(temp_dir) / Path(filename).name)
+            dir_importer = self.PackageImporter(Path(temp_dir) / Path(filename).name)
             m = dir_importer.import_module("main")
             self.assertEqual(m.s, "my string")
 
@@ -260,12 +274,16 @@ class DirectoryReaderTest(PackageTestCase):
         Test basic saving and loading of a ScriptModule in a directory.
         Currently not supported.
         """
+
+        if self.PackageExporter != PackageExporter:
+            return
+
         from package_a.test_module import ModWithTensor
 
         scripted_mod = torch.jit.script(ModWithTensor(torch.rand(1, 2, 3)))
 
         filename = self.temp()
-        with PackageExporter(filename) as e:
+        with self.PackageExporter(filename) as e:
             e.save_pickle("res", "mod.pkl", scripted_mod)
 
         zip_file = zipfile.ZipFile(filename, "r")
@@ -277,8 +295,17 @@ class DirectoryReaderTest(PackageTestCase):
         ):
             with TemporaryDirectory() as temp_dir:
                 zip_file.extractall(path=temp_dir)
-                dir_importer = PackageImporter(Path(temp_dir) / Path(filename).name)
+                dir_importer = self.PackageImporter(
+                    Path(temp_dir) / Path(filename).name
+                )
                 dir_mod = dir_importer.load_pickle("res", "mod.pkl")
+
+
+class DirectoryReaderTestNoTorch(DirectoryReaderTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageExporter = PackageExporterNoTorch
+        self.PackageImporter = PackageImporterNoTorch
 
 
 if __name__ == "__main__":

--- a/test/package/test_importer.py
+++ b/test/package/test_importer.py
@@ -10,6 +10,12 @@ from package import (
     PackageImporter,
     sys_importer,
 )
+from package.package_exporter_no_torch import (
+    PackageExporter as PackageExporterNoTorch,
+)
+from package.package_importer_no_torch import (
+    PackageImporter as PackageImporterNoTorch,
+)
 from torch.testing._internal.common_utils import run_tests
 
 try:
@@ -21,6 +27,11 @@ except ImportError:
 
 class TestImporter(PackageTestCase):
     """Tests for Importer and derived classes."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporter
+        self.PackageExporter = PackageExporter
 
     def test_sys_importer(self):
         import package_a
@@ -47,11 +58,11 @@ class TestImporter(PackageTestCase):
         import package_a
 
         buffer = BytesIO()
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             pe.save_module(package_a.__name__)
 
         buffer.seek(0)
-        importer = PackageImporter(buffer)
+        importer = self.PackageImporter(buffer)
 
         # Construct an importer-only environment.
         ordered_importer = OrderedImporter(importer)
@@ -73,11 +84,11 @@ class TestImporter(PackageTestCase):
         import package_a
 
         buffer = BytesIO()
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             pe.save_module(package_a.__name__)
 
         buffer.seek(0)
-        importer = PackageImporter(buffer)
+        importer = self.PackageImporter(buffer)
 
         ordered_importer_sys_first = OrderedImporter(sys_importer, importer)
         self.assertIs(ordered_importer_sys_first.import_module("package_a"), package_a)
@@ -137,24 +148,31 @@ class TestImporter(PackageTestCase):
 
         # Set up a PackageImporter which has a torch.float16 object pickled:
         buffer = BytesIO()
-        with PackageExporter(buffer) as exporter:
+        with self.PackageExporter(buffer) as exporter:
             exporter.save_pickle("foo", "foo.pkl", my_dtype)
         buffer.seek(0)
 
-        importer = PackageImporter(buffer)
+        importer = self.PackageImporter(buffer)
         my_loaded_dtype = importer.load_pickle("foo", "foo.pkl")
 
         # Re-save a package with only our PackageImporter as the importer
         buffer2 = BytesIO()
-        with PackageExporter(buffer2, importer=importer) as exporter:
+        with self.PackageExporter(buffer2, importer=importer) as exporter:
             exporter.save_pickle("foo", "foo.pkl", my_loaded_dtype)
 
         buffer2.seek(0)
 
-        importer2 = PackageImporter(buffer2)
+        importer2 = self.PackageImporter(buffer2)
         my_loaded_dtype2 = importer2.load_pickle("foo", "foo.pkl")
         self.assertIs(my_dtype, my_loaded_dtype)
         self.assertIs(my_dtype, my_loaded_dtype2)
+
+
+class TestImporterNoTorch(TestImporter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporterNoTorch
+        self.PackageExporter = PackageExporterNoTorch
 
 
 if __name__ == "__main__":

--- a/test/package/test_mangling.py
+++ b/test/package/test_mangling.py
@@ -9,6 +9,12 @@ from package._mangling import (
     get_mangle_prefix,
     is_mangled,
 )
+from package.package_exporter_no_torch import (
+    PackageExporter as PackageExporterNoTorch,
+)
+from package.package_importer_no_torch import (
+    PackageImporter as PackageImporterNoTorch,
+)
 from torch.testing._internal.common_utils import run_tests
 
 try:
@@ -19,6 +25,11 @@ except ImportError:
 
 
 class TestMangling(PackageTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporter
+        self.PackageExporter = PackageExporter
+
     def test_unique_manglers(self):
         """
         Each mangler instance should generate a unique mangled name for a given input.
@@ -83,11 +94,11 @@ class TestMangling(PackageTestCase):
         obj = package_a.subpackage.PackageASubpackageObject()
         obj2 = package_a.PackageAObject(obj)
         f1 = BytesIO()
-        with PackageExporter(f1) as pe:
+        with self.PackageExporter(f1) as pe:
             pe.intern("**")
             pe.save_pickle("obj", "obj.pkl", obj2)
         f1.seek(0)
-        importer1 = PackageImporter(f1)
+        importer1 = self.PackageImporter(f1)
         loaded1 = importer1.load_pickle("obj", "obj.pkl")
         f1.seek(0)
         importer2 = PackageImporter(f1)
@@ -106,6 +117,13 @@ class TestMangling(PackageTestCase):
         self.assertEqual(a.demangle(a_mangled), "foo.bar")
         # Since `b` did not mangle this string, demangling should leave it alone.
         self.assertEqual(b.demangle(a_mangled), a_mangled)
+
+
+class TestManglingNoTorch(TestMangling):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporterNoTorch
+        self.PackageExporter = PackageExporterNoTorch
 
 
 if __name__ == "__main__":

--- a/test/package/test_misc.py
+++ b/test/package/test_misc.py
@@ -8,9 +8,19 @@ from pathlib import Path
 from textwrap import dedent
 from unittest import skipIf
 
-from package import PackageExporter, PackageImporter, is_from_package
-from package.package_exporter_no_torch import PackagingError
-from torch.testing._internal.common_utils import IS_FBCODE, IS_SANDCASTLE, run_tests
+from package import (
+    PackageExporter,
+    PackageImporter,
+    is_from_package,
+    PackagingError,
+)
+from package.package_exporter_no_torch import (
+    PackageExporter as PackageExporterNoTorch,
+)
+from package.package_importer_no_torch import (
+    PackageImporter as PackageImporterNoTorch,
+)
+from torch.testing._internal.common_utils import run_tests, IS_FBCODE, IS_SANDCASTLE
 
 try:
     from .common import PackageTestCase
@@ -21,6 +31,11 @@ except ImportError:
 
 class TestMisc(PackageTestCase):
     """Tests for one-off or random functionality. Try not to add to this!"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporter
+        self.PackageExporter = PackageExporter
 
     def test_file_structure(self):
         """
@@ -71,7 +86,7 @@ class TestMisc(PackageTestCase):
             """
         )
 
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             import module_a
             import package_a
             import package_a.subpackage
@@ -84,7 +99,7 @@ class TestMisc(PackageTestCase):
             he.save_text("main", "main", "my string")
 
         buffer.seek(0)
-        hi = PackageImporter(buffer)
+        hi = self.PackageImporter(buffer)
 
         file_structure = hi.file_structure()
         # remove first line from testing because WINDOW/iOS/Unix treat the buffer differently
@@ -139,7 +154,7 @@ class TestMisc(PackageTestCase):
         Test Directory's has_file() method.
         """
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             import package_a.subpackage
 
             he.intern("**")
@@ -148,7 +163,7 @@ class TestMisc(PackageTestCase):
 
         buffer.seek(0)
 
-        importer = PackageImporter(buffer)
+        importer = self.PackageImporter(buffer)
         file_structure = importer.file_structure()
         self.assertTrue(file_structure.has_file("package_a/subpackage.py"))
         self.assertFalse(file_structure.has_file("package_a/subpackage"))
@@ -158,7 +173,7 @@ class TestMisc(PackageTestCase):
         Test content list API for PackageExporter's contained modules.
         """
 
-        with PackageExporter(BytesIO()) as he:
+        with self.PackageExporter(BytesIO()) as he:
             import package_b
 
             he.extern("package_b.subpackage_1")
@@ -174,7 +189,7 @@ class TestMisc(PackageTestCase):
             self.assertEqual(he.get_rdeps("package_b.subpackage_2"), ["package_b"])
 
         with self.assertRaises(PackagingError) as e:
-            with PackageExporter(BytesIO()) as he:
+            with self.PackageExporter(BytesIO()) as he:
                 import package_b
 
                 he.deny("package_b")
@@ -188,12 +203,12 @@ class TestMisc(PackageTestCase):
         buffer = BytesIO()
         obj = package_a.subpackage.PackageASubpackageObject()
 
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             pe.intern("**")
             pe.save_pickle("obj", "obj.pkl", obj)
 
         buffer.seek(0)
-        pi = PackageImporter(buffer)
+        pi = self.PackageImporter(buffer)
         mod = pi.import_module("package_a.subpackage")
         loaded_obj = pi.load_pickle("obj", "obj.pkl")
 
@@ -210,12 +225,12 @@ class TestMisc(PackageTestCase):
         buffer = BytesIO()
         obj = package_a.subpackage.PackageASubpackageObject()
 
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             pe.intern("**")
             pe.save_pickle("obj", "obj.pkl", obj)
 
         buffer.seek(0)
-        pi = PackageImporter(buffer)
+        pi = self.PackageImporter(buffer)
         packaged_class = pi.import_module(
             "package_a.subpackage"
         ).PackageASubpackageObject
@@ -234,12 +249,12 @@ class TestMisc(PackageTestCase):
         buffer = BytesIO()
         obj = package_a.subpackage.PackageASubpackageObject()
 
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             pe.intern("**")
             pe.save_pickle("obj", "obj.pkl", obj)
 
         buffer.seek(0)
-        pi = PackageImporter(buffer)
+        pi = self.PackageImporter(buffer)
         mod = pi.import_module("package_a.subpackage")
         self.assertTrue(hasattr(mod, "__torch_package__"))
 
@@ -253,12 +268,12 @@ class TestMisc(PackageTestCase):
 
         buffer = BytesIO()
 
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             pe.intern("**")
             pe.save_module(mod.__name__)
 
         buffer.seek(0)
-        pi = PackageImporter(buffer)
+        pi = self.PackageImporter(buffer)
         imported_mod = pi.import_module(mod.__name__)
         self.assertTrue(imported_mod.is_from_package())
         self.assertFalse(mod.is_from_package())
@@ -274,14 +289,21 @@ class TestMisc(PackageTestCase):
         buffer = BytesIO()
         mod = package_a.std_sys_module_hacks.Module()
 
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             pe.intern("**")
             pe.save_pickle("obj", "obj.pkl", mod)
 
         buffer.seek(0)
-        pi = PackageImporter(buffer)
+        pi = self.PackageImporter(buffer)
         mod = pi.load_pickle("obj", "obj.pkl")
         mod()
+
+
+class TestMiscNoTorch(TestMisc):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporterNoTorch
+        self.PackageExporter = PackageExporterNoTorch
 
 
 if __name__ == "__main__":

--- a/test/package/test_package_script.py
+++ b/test/package/test_package_script.py
@@ -25,6 +25,7 @@ try:
 except ImportError:
     HAS_TORCHVISION = False
 skipIfNoTorchVision = skipIf(not HAS_TORCHVISION, "no torchvision")
+import package
 
 
 class TestPackageScript(PackageTestCase):
@@ -624,7 +625,6 @@ class TestPackageScript(PackageTestCase):
         buffer_1.seek(0)
         importer = PackageImporter(buffer_1)
         loaded_mod_1 = importer.load_pickle("res", "mod1.pkl")
-
         self.assertEqual(
             loaded_mod_1.tensor.storage()._cdata,
             loaded_mod_1.sub_mod_0.tensor.storage()._cdata,
@@ -775,7 +775,7 @@ class TestPackageScript(PackageTestCase):
         original_tensor = torch.ones(0)
 
         f = BytesIO()
-        with PackageExporter(f) as exporter:
+        with package.PackageExporter(f) as exporter:
             exporter.save_pickle("model", "model.pkl", scripted_m)
             exporter.save_pickle("model", "input.pkl", original_tensor)
 

--- a/test/package/test_repackage.py
+++ b/test/package/test_repackage.py
@@ -7,6 +7,12 @@ from package import (
     PackageImporter,
     sys_importer,
 )
+from package.package_exporter_no_torch import (
+    PackageExporter as PackageExporterNoTorch,
+)
+from package.package_importer_no_torch import (
+    PackageImporter as PackageImporterNoTorch,
+)
 from torch.testing._internal.common_utils import run_tests
 
 try:
@@ -19,23 +25,28 @@ except ImportError:
 class TestRepackage(PackageTestCase):
     """Tests for repackaging."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporter
+        self.PackageExporter = PackageExporter
+
     def test_repackage_import_indirectly_via_parent_module(self):
         from package_d.imports_directly import ImportsDirectlyFromSubSubPackage
         from package_d.imports_indirectly import ImportsIndirectlyFromSubPackage
 
         model_a = ImportsDirectlyFromSubSubPackage()
         buffer = BytesIO()
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             pe.intern("**")
             pe.save_pickle("default", "model.py", model_a)
 
         buffer.seek(0)
-        pi = PackageImporter(buffer)
+        pi = self.PackageImporter(buffer)
         loaded_model = pi.load_pickle("default", "model.py")
 
         model_b = ImportsIndirectlyFromSubPackage()
         buffer = BytesIO()
-        with PackageExporter(
+        with self.PackageExporter(
             buffer,
             importer=(
                 pi,
@@ -44,6 +55,13 @@ class TestRepackage(PackageTestCase):
         ) as pe:
             pe.intern("**")
             pe.save_pickle("default", "model_b.py", model_b)
+
+
+class TestRepackageNoTorch(TestRepackage):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporterNoTorch
+        self.PackageExporter = PackageExporterNoTorch
 
 
 if __name__ == "__main__":

--- a/test/package/test_resources.py
+++ b/test/package/test_resources.py
@@ -7,6 +7,12 @@ from textwrap import dedent
 from unittest import skipIf
 
 from package import PackageExporter, PackageImporter
+from package.package_exporter_no_torch import (
+    PackageExporter as PackageExporterNoTorch,
+)
+from package.package_importer_no_torch import (
+    PackageImporter as PackageImporterNoTorch,
+)
 from torch.testing._internal.common_utils import run_tests
 
 try:
@@ -20,10 +26,15 @@ except ImportError:
 class TestResources(PackageTestCase):
     """Tests for access APIs for packaged resources."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporter
+        self.PackageExporter = PackageExporter
+
     def test_resource_reader(self):
         """Test compliance with the get_resource_reader importlib API."""
         buffer = BytesIO()
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             # Layout looks like:
             #    package
             #    ├── one/
@@ -47,7 +58,7 @@ class TestResources(PackageTestCase):
             pe.save_text("two", "g.txt", "hello, g!")
 
         buffer.seek(0)
-        importer = PackageImporter(buffer)
+        importer = self.PackageImporter(buffer)
 
         reader_one = importer.get_resource_reader("one")
         with self.assertRaises(FileNotFoundError):
@@ -91,19 +102,19 @@ class TestResources(PackageTestCase):
             """
         )
         buffer = BytesIO()
-        with PackageExporter(buffer) as pe:
+        with self.PackageExporter(buffer) as pe:
             pe.save_source_string("foo.bar", mod_src)
             pe.save_text("my_cool_resources", "sekrit.txt", "my sekrit plays")
 
         buffer.seek(0)
-        importer = PackageImporter(buffer)
+        importer = self.PackageImporter(buffer)
         self.assertEqual(
             importer.import_module("foo.bar").secret_message(), "my sekrit plays"
         )
 
     def test_importer_access(self):
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             he.save_text("main", "main", "my string")
             he.save_binary("main", "main_binary", "my string".encode("utf-8"))
             src = dedent(
@@ -117,7 +128,7 @@ class TestResources(PackageTestCase):
             )
             he.save_source_string("main", src, is_package=True)
         buffer.seek(0)
-        hi = PackageImporter(buffer)
+        hi = self.PackageImporter(buffer)
         m = hi.import_module("main")
         self.assertEqual(m.t, "my string")
         self.assertEqual(m.b, "my string".encode("utf-8"))
@@ -127,7 +138,7 @@ class TestResources(PackageTestCase):
         Tests that packaged code can used importlib.resources.path.
         """
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             he.save_binary("string_module", "my_string", "my string".encode("utf-8"))
             src = dedent(
                 """\
@@ -141,9 +152,16 @@ class TestResources(PackageTestCase):
             )
             he.save_source_string("main", src, is_package=True)
         buffer.seek(0)
-        hi = PackageImporter(buffer)
+        hi = self.PackageImporter(buffer)
         m = hi.import_module("main")
         self.assertEqual(m.s, "my string")
+
+
+class TestResourcesNoTorch(TestResources):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporterNoTorch
+        self.PackageExporter = PackageExporterNoTorch
 
 
 if __name__ == "__main__":

--- a/test/package/test_save_load.py
+++ b/test/package/test_save_load.py
@@ -6,6 +6,12 @@ from textwrap import dedent
 from unittest import skipIf
 
 from package import PackageExporter, PackageImporter, sys_importer
+from package.package_exporter_no_torch import (
+    PackageExporter as PackageExporterNoTorch,
+)
+from package.package_importer_no_torch import (
+    PackageImporter as PackageImporterNoTorch,
+)
 from torch.testing._internal.common_utils import run_tests, IS_FBCODE, IS_SANDCASTLE
 
 try:
@@ -22,16 +28,21 @@ packaging_directory = Path(__file__).parent
 class TestSaveLoad(PackageTestCase):
     """Core save_* and loading API tests."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporter
+        self.PackageExporter = PackageExporter
+
     @skipIf(
         IS_FBCODE or IS_SANDCASTLE,
         "Tests that use temporary files are disabled in fbcode",
     )
     def test_saving_source(self):
         filename = self.temp()
-        with PackageExporter(filename) as he:
+        with self.PackageExporter(filename) as he:
             he.save_source_file("foo", str(packaging_directory / "module_a.py"))
             he.save_source_file("foodir", str(packaging_directory / "package_a"))
-        hi = PackageImporter(filename)
+        hi = self.PackageImporter(filename)
         foo = hi.import_module("foo")
         s = hi.import_module("foodir.subpackage")
         self.assertEqual(foo.result, "module_a")
@@ -43,7 +54,7 @@ class TestSaveLoad(PackageTestCase):
     )
     def test_saving_string(self):
         filename = self.temp()
-        with PackageExporter(filename) as he:
+        with self.PackageExporter(filename) as he:
             src = dedent(
                 """\
                 import math
@@ -51,7 +62,7 @@ class TestSaveLoad(PackageTestCase):
                 """
             )
             he.save_source_string("my_mod", src)
-        hi = PackageImporter(filename)
+        hi = self.PackageImporter(filename)
         m = hi.import_module("math")
         import math
 
@@ -65,13 +76,13 @@ class TestSaveLoad(PackageTestCase):
     )
     def test_save_module(self):
         filename = self.temp()
-        with PackageExporter(filename) as he:
+        with self.PackageExporter(filename) as he:
             import module_a
             import package_a
 
             he.save_module(module_a.__name__)
             he.save_module(package_a.__name__)
-        hi = PackageImporter(filename)
+        hi = self.PackageImporter(filename)
         module_a_i = hi.import_module("module_a")
         self.assertEqual(module_a_i.result, "module_a")
         self.assertIsNot(module_a, module_a_i)
@@ -81,7 +92,7 @@ class TestSaveLoad(PackageTestCase):
 
     def test_dunder_imports(self):
         buffer = BytesIO()
-        with PackageExporter(buffer) as he:
+        with self.PackageExporter(buffer) as he:
             import package_b
 
             obj = package_b.PackageBObject
@@ -89,7 +100,7 @@ class TestSaveLoad(PackageTestCase):
             he.save_pickle("res", "obj.pkl", obj)
 
         buffer.seek(0)
-        hi = PackageImporter(buffer)
+        hi = self.PackageImporter(buffer)
         loaded_obj = hi.load_pickle("res", "obj.pkl")
 
         package_b = hi.import_module("package_b")
@@ -113,21 +124,21 @@ class TestSaveLoad(PackageTestCase):
     def test_bad_dunder_imports(self):
         """Test to ensure bad __imports__ don't cause PackageExporter to fail."""
         buffer = BytesIO()
-        with PackageExporter(buffer) as e:
+        with self.PackageExporter(buffer) as e:
             e.save_source_string(
                 "m", '__import__(these, unresolvable, "things", wont, crash, me)'
             )
 
     def test_save_module_binary(self):
         f = BytesIO()
-        with PackageExporter(f) as he:
+        with self.PackageExporter(f) as he:
             import module_a
             import package_a
 
             he.save_module(module_a.__name__)
             he.save_module(package_a.__name__)
         f.seek(0)
-        hi = PackageImporter(f)
+        hi = self.PackageImporter(f)
         module_a_i = hi.import_module("module_a")
         self.assertEqual(module_a_i.result, "module_a")
         self.assertIsNot(module_a, module_a_i)
@@ -146,10 +157,10 @@ class TestSaveLoad(PackageTestCase):
         obj2 = package_a.PackageAObject(obj)
 
         filename = self.temp()
-        with PackageExporter(filename) as he:
+        with self.PackageExporter(filename) as he:
             he.intern("**")
             he.save_pickle("obj", "obj.pkl", obj2)
-        hi = PackageImporter(filename)
+        hi = self.PackageImporter(filename)
 
         # check we got dependencies
         sp = hi.import_module("package_a.subpackage")
@@ -179,19 +190,19 @@ class TestSaveLoad(PackageTestCase):
         obj = package_a.subpackage.PackageASubpackageObject()
         obj2 = package_a.PackageAObject(obj)
         f1 = self.temp()
-        with PackageExporter(f1) as pe:
+        with self.PackageExporter(f1) as pe:
             pe.intern("**")
             pe.save_pickle("obj", "obj.pkl", obj2)
 
-        importer1 = PackageImporter(f1)
+        importer1 = self.PackageImporter(f1)
         loaded1 = importer1.load_pickle("obj", "obj.pkl")
-        importer2 = PackageImporter(f1)
+        importer2 = self.PackageImporter(f1)
         loaded2 = importer2.load_pickle("obj", "obj.pkl")
 
         f2 = self.temp()
 
         def make_exporter():
-            pe = PackageExporter(f2, importer=[importer1, sys_importer])
+            pe = self.PackageExporter(f2, importer=[importer1, sys_importer])
             # Ensure that the importer finds the 'PackageAObject' defined in 'importer1' first.
             return pe
 
@@ -220,19 +231,21 @@ class TestSaveLoad(PackageTestCase):
         obj2 = package_a.PackageAObject(obj)
 
         buffer = BytesIO()
-        with PackageExporter(buffer) as exporter:
+        with self.PackageExporter(buffer) as exporter:
             exporter.intern("**")
             exporter.save_pickle("model", "model.pkl", obj2)
 
         buffer.seek(0)
 
-        importer = PackageImporter(buffer)
+        importer = self.PackageImporter(buffer)
         imported_obj2 = importer.load_pickle("model", "model.pkl")
         imported_obj2_module = imported_obj2.__class__.__module__
 
         # Should export without error.
         buffer2 = BytesIO()
-        with PackageExporter(buffer2, importer=(importer, sys_importer)) as exporter:
+        with self.PackageExporter(
+            buffer2, importer=(importer, sys_importer)
+        ) as exporter:
             exporter.intern("**")
             exporter.save_module(imported_obj2_module)
 
@@ -241,19 +254,28 @@ class TestSaveLoad(PackageTestCase):
         import package_a.use_torch_package_importer  # noqa: F401
 
         buffer = BytesIO()
-        with PackageExporter(buffer) as exporter:
+        with self.PackageExporter(buffer) as exporter:
             exporter.intern("**")
             exporter.save_module("package_a.use_torch_package_importer")
 
         buffer.seek(0)
 
-        importer = PackageImporter(buffer)
+        importer = self.PackageImporter(buffer)
 
         # Should export without error.
         buffer2 = BytesIO()
-        with PackageExporter(buffer2, importer=(importer, sys_importer)) as exporter:
+        with self.PackageExporter(
+            buffer2, importer=(importer, sys_importer)
+        ) as exporter:
             exporter.intern("**")
             exporter.save_module("package_a.use_torch_package_importer")
+
+
+class TestSaveLoadNoTorch(TestSaveLoad):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.PackageImporter = PackageImporterNoTorch
+        self.PackageExporter = PackageExporterNoTorch
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Allow package unit tests to also work without torch support if they can.

Reviewed By: d4l3k

Differential Revision: D35634354

