### PR TITLE
Improve PackageError message

### DIFF
--- a/package/package_exporter_no_torch.py
+++ b/package/package_exporter_no_torch.py
@@ -142,6 +142,13 @@ class PackagingError(Exception):
                 if error_context is not None:
                     message.write(f"      Context: {error_context}\n")
 
+        troubleshooting_str = (
+            "We offer tools to help you figure out why modules were included as a dependency\n"
+            "to help you figure out if they are actually needed here:\n"
+            "https://pytorch.org/docs/stable/package.html#see-why-a-given-module-was-included-as-a-dependency.\n"
+        )
+        message.write(troubleshooting_str)
+
         # Save the dependency graph so that tooling can get at it.
         self.dependency_graph = dependency_graph
         super().__init__(message.getvalue())

--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -261,6 +261,9 @@ class TestDependencyAPI(PackageTestCase):
                 * Module did not match against any action pattern. Extern, mock, or intern it.
                     package_a
                     package_a.subpackage
+                We offer tools to help you figure out why modules were included as a dependency
+                to help you figure out if they are actually needed here:
+                https://pytorch.org/docs/stable/package.html#see-why-a-given-module-was-included-as-a-dependency.
                 """
             ),
         )
@@ -308,6 +311,9 @@ class TestDependencyAPI(PackageTestCase):
                 * Module is a C extension module. package supports Python modules only.
                     foo
                     bar
+                We offer tools to help you figure out why modules were included as a dependency
+                to help you figure out if they are actually needed here:
+                https://pytorch.org/docs/stable/package.html#see-why-a-given-module-was-included-as-a-dependency.
                 """
             ),
         )
@@ -327,6 +333,9 @@ class TestDependencyAPI(PackageTestCase):
                 * Dependency resolution failed.
                     foo
                       Context: attempted relative import beyond top-level package
+                We offer tools to help you figure out why modules were included as a dependency
+                to help you figure out if they are actually needed here:
+                https://pytorch.org/docs/stable/package.html#see-why-a-given-module-was-included-as-a-dependency.
                 """
             ),
         )


### PR DESCRIPTION
Summary:
Adds a better error message for `PackageError` in order to point users to troubleshooting tools. This way in projects where package is used upstream with a set of `intern/extern/mock` rules it becomes more obvious what to do with the list of dependencies you get and how to get rid of them.

We also update documentation to add `package.analyze.find_first_use_of_broken_modules` as a troubleshooting tool

This diff reflects https://github.com/pytorch/pytorch/pull/75842 in pytorch core

Differential Revision: D35659123

