### PR TITLE
pin multipy/runtime/third-party/pytorch to 1.12

### DIFF
--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -102,7 +102,7 @@ add_custom_command(
 # make sure system python isn't used here
 add_library(torch_python_static STATIC IMPORTED)
 set_property(TARGET torch_python_static PROPERTY
-             IMPORTED_LOCATION "${PYTORCH_ROOT}/torch/lib64/libtorch_python_static.a")
+             IMPORTED_LOCATION "${PYTORCH_ROOT}/torch/lib/libtorch_python_static.a")
 # Build the interpreter lib, designed to be standalone and dlopened
 # We bake the python and torch_python binding objs into libinterpreter
 set(INTERPRETER_LIB_SOURCES


### PR DESCRIPTION
Pins `multipy/runtime/third-party/pytorch` to release 1.12 which is a stable release. This makes it easier for users to actually get the repo up and running as they would commonly use the stable release.