### PR TITLE
add multipy to distribution path

### DIFF
--- a/.github/workflows/runtime_nightly.yaml
+++ b/.github/workflows/runtime_nightly.yaml
@@ -97,13 +97,6 @@ jobs:
         run: |
               cd multipy/runtime/build
               conda run -n multipy_runtime_env cmake --install . --prefix "."
-      - name: create tarball [click me to get a list of files for the nightly release]
-        shell: bash -l {0}
-        env:
-          PYTHON_VERSION: ${{ matrix.python-version }}
-        run: |
-              cd multipy/runtime/build/dist
-              tar -czvf multipy_runtime.tar.gz runtime/
 
       - name: Run unit tests with ABI=${{ matrix.abi }}
         if: ${{ matrix.abi }} == 1
@@ -113,6 +106,14 @@ jobs:
         run: |
               cd multipy/runtime/build
               ./test_deploy
+
+      - name: create tarball [click me to get a list of files for the nightly release]
+        shell: bash -l {0}
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+              cd multipy/runtime/build/dist
+              tar -czvf multipy_runtime.tar.gz multipy/
 
       - name: Update nightly release
         if: ${{ matrix.abi }} == 0

--- a/multipy/runtime/CMakeLists.txt
+++ b/multipy/runtime/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 
 install (
     DIRECTORY ${CMAKE_SOURCE_DIR}
-    DESTINATION dist
+    DESTINATION dist/multipy
     FILES_MATCHING
     PATTERN "*.h*"
     PATTERN "utils.cmake"
@@ -134,20 +134,5 @@ install (
     PATTERN "example" EXCLUDE
     )
 
-install (
-    DIRECTORY ${CMAKE_SOURCE_DIR}
-    DESTINATION multipy
-    FILES_MATCHING
-    PATTERN "example/generated/*"
-    PATTERN "test_deploy_python.py"
-    PATTERN "interpreter/third_party" EXCLUDE
-    PATTERN "interpreter/cpython" EXCLUDE
-    PATTERN "interpreter/frozen" EXCLUDE
-    PATTERN "third-party" EXCLUDE
-    PATTERN "build" EXCLUDE
-    PATTERN "unity" EXCLUDE
-    PATTERN "__pycache__" EXCLUDE
-    )
-
-install(TARGETS torch_deploy DESTINATION dist/runtime/lib)
-install(TARGETS torch_deployinterpreter DESTINATION dist/runtime/lib)
+install(TARGETS torch_deploy DESTINATION dist/multipy/runtime/lib)
+install(TARGETS torch_deployinterpreter DESTINATION dist/multipy/runtime/lib)

--- a/multipy/runtime/CMakeLists.txt
+++ b/multipy/runtime/CMakeLists.txt
@@ -134,5 +134,20 @@ install (
     PATTERN "example" EXCLUDE
     )
 
+install (
+    DIRECTORY ${CMAKE_SOURCE_DIR}
+    DESTINATION multipy
+    FILES_MATCHING
+    PATTERN "example/generated/*"
+    PATTERN "test_deploy_python.py"
+    PATTERN "interpreter/third_party" EXCLUDE
+    PATTERN "interpreter/cpython" EXCLUDE
+    PATTERN "interpreter/frozen" EXCLUDE
+    PATTERN "third-party" EXCLUDE
+    PATTERN "build" EXCLUDE
+    PATTERN "unity" EXCLUDE
+    PATTERN "__pycache__" EXCLUDE
+    )
+
 install(TARGETS torch_deploy DESTINATION dist/multipy/runtime/lib)
 install(TARGETS torch_deployinterpreter DESTINATION dist/multipy/runtime/lib)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #79
* #71

This PR addresses https://github.com/pytorch/multipy/issues/76 by adding multipy to the path of the headers in the distribution.

Differential Revision: [D37424533](https://our.internmc.facebook.com/intern/diff/D37424533)