### PR TITLE
pin pytorch to release/1.12 branch

### DIFF
--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -1,4 +1,4 @@
-name: Multipy runtime nightly release
+name: Multipy runtime tests
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # \[experimental\] MultiPy
 
-> :warning: **This is project is still a prototype.** Only Linux x86 is supported, and the API may change without warning.
+> :warning: **This is project is still a prototype.** Only Linux x86 is supported, and the API may change without warning. Furthermore, please **USE PYTORCH RELEASE 1.12** when using `multipy::runtime`!
 
 `MultiPy` (formerly `torch::deploy` and `torch.package`) is a system that allows you to run multi-threaded python code in C++. It offers `multipy.package` (formerly `torch.package`) in order to package code into a mostly hermetic format to deliver to `multipy::runtime` (formerly `torch::deploy`) which is a runtime which takes packaged
 code and runs it using multiple embedded Python interpreters in a C++ process without a shared global interpreter lock (GIL). For more information on how `MultiPy` works

--- a/multipy/runtime/environment.h
+++ b/multipy/runtime/environment.h
@@ -5,7 +5,6 @@
 // LICENSE file in the root directory of this source tree.
 
 #pragma once
-#include <fmt/format.h>
 #include <fstream>
 #include <string>
 #include "Exception.h"
@@ -62,7 +61,7 @@ class Environment {
     setupZippedPythonModules(pythonAppDir);
   }
   virtual ~Environment() {
-    auto rmCmd = fmt::format("rm -rf {}", extraPythonLibrariesDir_);
+    auto rmCmd = "rm -rf " + extraPythonLibrariesDir_;
     system(rmCmd.c_str());
   }
   virtual void configureInterpreter(Interpreter* interp) = 0;


### PR DESCRIPTION
Pins `multipy/runtime/third-party/pytorch` to [release/1.12](https://github.com/pytorch/pytorch/releases/tag/v1.12.0) as it's been finalized! 

Also fixes a small typo in our github actions jobs.