### PR TITLE
add python 3.7 and 3.9 to test bench

### DIFF
--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -10,7 +10,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.7, 3.8, 3.9]
         platform: [linux.2xlarge]
         abi: [1]
       fail-fast: false

--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
         platform: [linux.2xlarge]
-        abi: [1]
+        abi: [0,1]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #85

This PR improves the test coverage for `multipy::runtime`. It 1) tests on python versions 3.7 and 3.9 in order to coincide with torch rec support for python 3.7-3.9 and 2) tests on ABI=0 in order to test our nightlies on PRs.

Differential Revision: [D37620099](https://our.internmc.facebook.com/intern/diff/D37620099)