### PR TITLE
multipy: pybind test

### DIFF
--- a/multipy/runtime/deploy.cpp
+++ b/multipy/runtime/deploy.cpp
@@ -58,12 +58,10 @@ static bool writeDeployInterpreter(FILE* dst) {
   const char* payloadStart = nullptr;
   size_t size = 0;
   bool customLoader = false;
-  std::string exePath;
-  std::ifstream("/proc/self/cmdline") >> exePath;
-  ElfFile elfFile(exePath.c_str());
+  // payloadSection needs to be kept to ensure the source file is still mapped.
+  multipy::optional<Section> payloadSection;
   for (const auto& s : pythonInterpreterSection) {
-    multipy::optional<Section> payloadSection =
-        elfFile.findSection(s.sectionName);
+    payloadSection = searchForSection(s.sectionName);
     if (payloadSection != multipy::nullopt) {
       payloadStart = payloadSection->start;
       customLoader = s.customLoader;

--- a/multipy/runtime/elf_file.cpp
+++ b/multipy/runtime/elf_file.cpp
@@ -4,6 +4,10 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <dlfcn.h>
+#include <link.h>
+#include <fstream>
+
 #include <c10/util/irange.h>
 #include <multipy/runtime/Exception.h>
 #include <multipy/runtime/elf_file.h>
@@ -12,8 +16,9 @@
 namespace torch {
 namespace deploy {
 
-ElfFile::ElfFile(const char* filename) : memFile_(filename) {
-  const char* fileData = memFile_.data();
+ElfFile::ElfFile(const char* filename)
+    : memFile_(std::make_shared<MemFile>(filename)) {
+  const char* fileData = memFile_->data();
   ehdr_ = (Elf64_Ehdr*)fileData;
   checkFormat();
 
@@ -56,6 +61,50 @@ void ElfFile::checkFormat() const {
       "Unexpected magic numbers");
   MULTIPY_CHECK(
       ehdr_->e_ident[EI_CLASS] == ELFCLASS64, "Only support 64bit ELF file");
+}
+
+namespace {
+// from https://stackoverflow.com/a/12774387/4722305
+// MIT license
+inline bool exists(const char* name) {
+  std::ifstream f(name);
+  return f.good();
+}
+} // namespace
+
+multipy::optional<Section> searchForSection(const char* name) {
+  {
+    std::string execPath;
+    std::ifstream("/proc/self/cmdline") >> execPath;
+    ElfFile elfFile(execPath.c_str());
+    auto section = elfFile.findSection(name);
+    if (section) {
+      return section;
+    }
+  }
+
+  struct context {
+    const char* name;
+    multipy::optional<Section> section{};
+  };
+  context ctx;
+  ctx.name = name;
+
+  dl_iterate_phdr(
+      [](struct dl_phdr_info* info, size_t, void* data) {
+        if (!exists(info->dlpi_name)) {
+          return 0;
+        }
+        ElfFile elfFile(info->dlpi_name);
+        auto localCtx = static_cast<context*>(data);
+        localCtx->section = elfFile.findSection(localCtx->name);
+        if (localCtx->section) {
+          return 1;
+        }
+        return 0;
+      },
+      &ctx);
+  return ctx.section;
 }
 
 } // namespace deploy

--- a/multipy/runtime/elf_file.h
+++ b/multipy/runtime/elf_file.h
@@ -16,14 +16,18 @@ namespace torch {
 namespace deploy {
 
 struct Section {
+  Section() {}
   explicit Section(
-      const char* _name = nullptr,
-      const char* _start = nullptr,
+      std::shared_ptr<MemFile> _memfile,
+      const char* _name,
+      const char* _start,
       size_t _len = 0)
-      : name(_name), start(_start), len(_len) {}
-  const char* name;
-  const char* start;
-  size_t len;
+      : memfile(_memfile), name(_name), start(_start), len(_len) {}
+
+  std::shared_ptr<MemFile> memfile;
+  const char* name{nullptr};
+  const char* start{nullptr};
+  size_t len{0};
 
   operator bool() const {
     return start != nullptr;
@@ -50,8 +54,8 @@ class ElfFile {
       MULTIPY_CHECK(nameOff >= 0 && nameOff < strtabSection_.len);
       name = strtabSection_.start + nameOff;
     }
-    const char* start = memFile_.data() + shOff;
-    return Section{name, start, len};
+    const char* start = memFile_->data() + shOff;
+    return Section{memFile_, name, start, len};
   }
 
   [[nodiscard]] const char* str(size_t off) const {
@@ -59,7 +63,7 @@ class ElfFile {
     return strtabSection_.start + off;
   }
   void checkFormat() const;
-  MemFile memFile_;
+  std::shared_ptr<MemFile> memFile_;
   Elf64_Ehdr* ehdr_;
   Elf64_Shdr* shdrList_;
   size_t numSections_;
@@ -67,6 +71,8 @@ class ElfFile {
   Section strtabSection_;
   std::vector<Section> sections_;
 };
+
+multipy::optional<Section> searchForSection(const char* name);
 
 } // namespace deploy
 } // namespace torch

--- a/multipy/runtime/environment.h
+++ b/multipy/runtime/environment.h
@@ -7,7 +7,6 @@
 #pragma once
 #include <multipy/runtime/Exception.h>
 #include <multipy/runtime/elf_file.h>
-#include <fstream>
 #include <string>
 
 namespace torch {
@@ -27,12 +26,9 @@ class Environment {
   std::string extraPythonLibrariesDir_;
   void setupZippedPythonModules(const std::string& pythonAppDir) {
 #ifdef FBCODE_CAFFE2
-    std::string execPath;
-    std::ifstream("/proc/self/cmdline") >> execPath;
-    ElfFile elfFile(execPath.c_str());
     // load the zipped torch modules
     constexpr const char* ZIPPED_TORCH_NAME = ".torch_python_modules";
-    auto zippedTorchSection = elfFile.findSection(ZIPPED_TORCH_NAME);
+    auto zippedTorchSection = searchForSection(ZIPPED_TORCH_NAME);
     MULTIPY_CHECK(
         zippedTorchSection.has_value(), "Missing the zipped torch section");
     const char* zippedTorchStart = zippedTorchSection->start;

--- a/multipy/runtime/test_deploy_python_ext.cpp
+++ b/multipy/runtime/test_deploy_python_ext.cpp
@@ -4,7 +4,7 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
-#include <caffe2/torch/csrc/deploy/deploy.h>
+#include <multipy/runtime/deploy.h>
 #include <pybind11/pybind11.h>
 #include <cstdint>
 #include <cstdio>

--- a/multipy/runtime/testdev/test_deploy_from_python.py
+++ b/multipy/runtime/testdev/test_deploy_from_python.py
@@ -4,10 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
+
+# @manual=//multipy/runtime:test_deploy_python_ext
 import test_deploy_python_ext
-from libfb.py import testutil
+
+import torch  # noqa: F401
 
 
-class TestDeployFromPython(testutil.BaseFacebookTestCase):
+class TestDeployFromPython(unittest.TestCase):
     def test_deploy_from_python(self):
         self.assertTrue(test_deploy_python_ext.run())


### PR DESCRIPTION
Summary:
This enables a previously broken (never working?) pybind test for multipy. This test and changes ensure that multipy/deploy can be pybinded into Python. The main gaps were that MultiPy was looking for the zipped sections/intepreter in the main executable where as now it searches all dynamically loaded libraries for the sections.

This might be slightly slower than when mulitpy is linked into the main binary since it has to mmap and search all loaded elf files but shouldn't be too bad as it only has to happen at initialization time.

Bonus: I think this means we can get rid of the _legacy variants since this is also fixed for interpreter loading.

One quirk of this is it that you need to manually import torch from Python first otherwise there's an undefined symbol error likely due to not being dynamically linked with all of `torch` upfront. Shouldn't be an issue in opt mode.

Reviewed By: PaliC

Differential Revision: D37492006

