### PR TITLE
multipy: add plugin_registry and plugin_torch

### DIFF
--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -110,6 +110,8 @@ set(INTERPRETER_LIB_SOURCES
   ${INTERPRETER_DIR}/builtin_registry.cpp
   ${INTERPRETER_DIR}/register_frozenpython.cpp
   ${INTERPRETER_DIR}/import_find_sharedfuncptr.cpp
+  ${INTERPRETER_DIR}/plugin_registry.cpp
+  ${INTERPRETER_DIR}/plugin_torch.cpp
   ${FROZEN_FILES}
   ${LINKER_SCRIPT}
 )

--- a/multipy/runtime/interpreter/Optional.hpp
+++ b/multipy/runtime/interpreter/Optional.hpp
@@ -294,7 +294,7 @@ union storage_t {
 
   template <class... Args>
   constexpr storage_t(Args&&... args)
-      : value_(constexpr_forward<Args>(args)...) {}
+      : value_(multipy::constexpr_forward<Args>(args)...) {}
 
   ~storage_t() {}
 };
@@ -308,7 +308,7 @@ union constexpr_storage_t {
 
   template <class... Args>
   constexpr constexpr_storage_t(Args&&... args)
-      : value_(constexpr_forward<Args>(args)...) {}
+      : value_(multipy::constexpr_forward<Args>(args)...) {}
 
   ~constexpr_storage_t() = default;
 };
@@ -323,11 +323,11 @@ struct optional_base {
   explicit constexpr optional_base(const T& v) : init_(true), storage_(v) {}
 
   explicit constexpr optional_base(T&& v)
-      : init_(true), storage_(constexpr_move(v)) {}
+      : init_(true), storage_(multipy::constexpr_move(v)) {}
 
   template <class... Args>
   explicit optional_base(in_place_t, Args&&... args)
-      : init_(true), storage_(constexpr_forward<Args>(args)...) {}
+      : init_(true), storage_(multipy::constexpr_forward<Args>(args)...) {}
 
   template <
       class U,
@@ -477,11 +477,13 @@ class optional : private OptionalBase<T> {
 
   constexpr optional(const T& v) : OptionalBase<T>(v) {}
 
-  constexpr optional(T&& v) : OptionalBase<T>(constexpr_move(v)) {}
+  constexpr optional(T&& v) : OptionalBase<T>(multipy::constexpr_move(v)) {}
 
   template <class... Args>
   explicit constexpr optional(in_place_t, Args&&... args)
-      : OptionalBase<T>(in_place_t{}, constexpr_forward<Args>(args)...) {}
+      : OptionalBase<T>(
+            in_place_t{},
+            multipy::constexpr_forward<Args>(args)...) {}
 
   template <
       class U,
@@ -491,7 +493,10 @@ class optional : private OptionalBase<T> {
       in_place_t,
       std::initializer_list<U> il,
       Args&&... args)
-      : OptionalBase<T>(in_place_t{}, il, constexpr_forward<Args>(args)...) {}
+      : OptionalBase<T>(
+            in_place_t{},
+            il,
+            multipy::constexpr_forward<Args>(args)...) {}
 
   // 20.5.4.2, Destructor
   ~optional() = default;
@@ -595,7 +600,7 @@ class optional : private OptionalBase<T> {
 
   OPTIONAL_MUTABLE_CONSTEXPR T&& operator*() && {
     assert(initialized());
-    return constexpr_move(contained_val());
+    return multipy::constexpr_move(contained_val());
   }
 
   constexpr T const& value() const& {
@@ -650,25 +655,26 @@ class optional : private OptionalBase<T> {
 
   template <class V>
   constexpr T value_or(V&& v) const& {
-    return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
+    return *this ? **this
+                 : detail_::convert<T>(multipy::constexpr_forward<V>(v));
   }
 
 #if OPTIONAL_HAS_MOVE_ACCESSORS == 1
 
   template <class V>
   OPTIONAL_MUTABLE_CONSTEXPR T value_or(V&& v) && {
-    return *this
-        ? constexpr_move(const_cast<optional<T>&>(*this).contained_val())
-        : detail_::convert<T>(constexpr_forward<V>(v));
+    return *this ? multipy::constexpr_move(
+                       const_cast<optional<T>&>(*this).contained_val())
+                 : detail_::convert<T>(multipy::constexpr_forward<V>(v));
   }
 
 #else
 
   template <class V>
   T value_or(V&& v) && {
-    return *this
-        ? constexpr_move(const_cast<optional<T>&>(*this).contained_val())
-        : detail_::convert<T>(constexpr_forward<V>(v));
+    return *this ? multipy::constexpr_move(
+                       const_cast<optional<T>&>(*this).contained_val())
+                 : detail_::convert<T>(multipy::constexpr_forward<V>(v));
   }
 
 #endif
@@ -677,7 +683,8 @@ class optional : private OptionalBase<T> {
 
   template <class V>
   constexpr T value_or(V&& v) const {
-    return *this ? **this : detail_::convert<T>(constexpr_forward<V>(v));
+    return *this ? **this
+                 : detail_::convert<T>(multipy::constexpr_forward<V>(v));
   }
 
 #endif
@@ -778,7 +785,7 @@ class optional<T&> {
   constexpr typename std::decay<T>::type value_or(V&& v) const {
     return *this ? **this
                  : detail_::convert<typename std::decay<T>::type>(
-                       constexpr_forward<V>(v));
+                       multipy::constexpr_forward<V>(v));
   }
 
   // x.x.x.x, modifiers
@@ -1075,7 +1082,8 @@ void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y))) {
 
 template <class T>
 constexpr optional<typename std::decay<T>::type> make_optional(T&& v) {
-  return optional<typename std::decay<T>::type>(constexpr_forward<T>(v));
+  return optional<typename std::decay<T>::type>(
+      multipy::constexpr_forward<T>(v));
 }
 
 template <class X>

--- a/multipy/runtime/interpreter/interpreter_impl.cpp
+++ b/multipy/runtime/interpreter/interpreter_impl.cpp
@@ -12,11 +12,12 @@
 #include <Python.h>
 
 #include <multipy/runtime/Exception.h>
+#include <multipy/runtime/interpreter/plugin_registry.h>
 #include <pybind11/embed.h>
 #include <pybind11/functional.h>
+#include <torch/csrc/Dtype.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
-#include <torch/csrc/jit/python/pybind_utils.h>
 
 #include <cassert>
 #include <cstdio>
@@ -258,7 +259,7 @@ struct __attribute__((visibility("hidden"))) ConcreteInterpreterSessionImpl
   }
 
   Obj fromIValue(IValue value) override {
-    return wrap(torch::jit::toPyObject(value));
+    return wrap(multipy::toPyObject(value));
   }
   Obj createOrGetPackageImporterFromContainerFile(
       const std::shared_ptr<caffe2::serialize::PyTorchStreamReader>&
@@ -328,7 +329,7 @@ struct __attribute__((visibility("hidden"))) ConcreteInterpreterSessionImpl
   }
 
   IValue toIValue(Obj obj) const override {
-    return torch::jit::toTypeInferredIValue(unwrap(obj));
+    return multipy::toTypeInferredIValue(unwrap(obj));
   }
 
   Obj call(Obj obj, at::ArrayRef<Obj> args) override {
@@ -342,7 +343,7 @@ struct __attribute__((visibility("hidden"))) ConcreteInterpreterSessionImpl
   Obj call(Obj obj, at::ArrayRef<IValue> args) override {
     py::tuple m_args(args.size());
     for (size_t i = 0, N = args.size(); i != N; ++i) {
-      m_args[i] = torch::jit::toPyObject(args[i]);
+      m_args[i] = multipy::toPyObject(args[i]);
     }
     return wrap(call(unwrap(obj), m_args));
   }
@@ -353,13 +354,13 @@ struct __attribute__((visibility("hidden"))) ConcreteInterpreterSessionImpl
       std::unordered_map<std::string, c10::IValue> kwargs) override {
     py::tuple py_args(args.size());
     for (size_t i = 0, N = args.size(); i != N; ++i) {
-      py_args[i] = torch::jit::toPyObject(args[i]);
+      py_args[i] = multipy::toPyObject(args[i]);
     }
 
     py::dict py_kwargs;
     for (auto kv : kwargs) {
       py_kwargs[py::cast(std::get<0>(kv))] =
-          torch::jit::toPyObject(std::get<1>(kv));
+          multipy::toPyObject(std::get<1>(kv));
     }
     return wrap(call(unwrap(obj), py_args, py_kwargs));
   }

--- a/multipy/runtime/interpreter/plugin_registry.cpp
+++ b/multipy/runtime/interpreter/plugin_registry.cpp
@@ -1,0 +1,34 @@
+#include "multipy/runtime/interpreter/plugin_registry.h"
+
+#include <vector>
+
+namespace multipy {
+
+std::vector<Converter*>& getConverters() {
+  static std::vector<Converter*> converters;
+  return converters;
+}
+
+void registerConverter(Converter* c) {
+  getConverters().emplace_back(c);
+}
+
+at::IValue toTypeInferredIValue(py::handle input) {
+  for (auto c : getConverters()) {
+    auto out = c->toTypeInferredIValue(input);
+    if (out) {
+      return *out;
+    }
+  }
+  throw std::runtime_error("failed to convert to IValue");
+}
+py::object toPyObject(at::IValue ivalue) {
+  for (auto c : getConverters()) {
+    auto out = c->toPyObject(ivalue);
+    if (out) {
+      return *out;
+    }
+  }
+  throw std::runtime_error("failed to convert to py::object");
+}
+} // namespace multipy

--- a/multipy/runtime/interpreter/plugin_registry.h
+++ b/multipy/runtime/interpreter/plugin_registry.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <ATen/core/ivalue.h>
+#include <pybind11/embed.h>
+#include <pybind11/functional.h>
+
+#include <multipy/runtime/interpreter/Optional.hpp>
+
+namespace py = pybind11;
+
+namespace multipy {
+
+class Converter {
+ public:
+  virtual ~Converter() = default;
+
+  virtual multipy::optional<at::IValue> toTypeInferredIValue(
+      py::handle input) = 0;
+  virtual multipy::optional<py::object> toPyObject(at::IValue ivalue) = 0;
+};
+
+void registerConverter(Converter*);
+
+at::IValue toTypeInferredIValue(py::handle input);
+py::object toPyObject(at::IValue ivalue);
+} // namespace multipy

--- a/multipy/runtime/interpreter/plugin_torch.cpp
+++ b/multipy/runtime/interpreter/plugin_torch.cpp
@@ -1,0 +1,43 @@
+#include <torch/csrc/jit/python/pybind_utils.h>
+#include <torch/csrc/lazy/core/debug_util.h>
+
+#include "plugin_registry.h"
+
+namespace multipy {
+namespace torch {
+
+namespace {
+
+class TorchConverter : public Converter {
+ public:
+  TorchConverter() {
+    registerConverter(this);
+  }
+
+  ~TorchConverter() override {
+    // GetPythonFramesFunction depends on the current python so we need to tear
+    // it down.
+    // https://www.internalfb.com/code/fbsource/[ead2dd7fd4a6]/fbcode/caffe2/torch/csrc/lazy/python/init.cpp?lines=293
+    ::torch::lazy::GetPythonFramesFunction() = nullptr;
+
+    // Deregister all pytorch operators since they might have been dynamically
+    // loaded so they won't deregister correctly on teardown.
+    /*
+    for (auto op : ::torch::jit::getAllOperators()) {
+      ::torch::jit::deregisterOperator(op->schema());
+    }
+    */
+  }
+
+  optional<at::IValue> toTypeInferredIValue(py::handle input) override {
+    return ::torch::jit::toTypeInferredIValue(input);
+  }
+  optional<py::object> toPyObject(at::IValue ivalue) override {
+    return ::torch::jit::toPyObject(ivalue);
+  }
+};
+
+TorchConverter converter;
+} // namespace
+} // namespace torch
+} // namespace multipy


### PR DESCRIPTION
Summary:
For dynamic loading we need to be able to load the interpreter without python or libtorch_python initially. Thus we need a plugin registry that we can use to late register the libtorch_python extension.

Load order:

* libinterpreter
* libpython
* libtorch_python
* plugin_torch.cpp

This adds the plugin registry but doesn't change the loading semantics -- a follow up diff will implement the dynamic loading.

The Optional.hpp changes are required since we're now using the move semantics which weren't used before in a torch context.

Differential Revision: D38093644

