### PR TITLE
[3.10+][1/n] Add conditional archiving for libmpdec module 

### DIFF
--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -13,17 +13,19 @@ include_directories(BEFORE "${PYTORCH_ROOT}/torch/include/torch/csrc/api/include
 SET(MULTIPY_UTILS "${CMAKE_CURRENT_SOURCE_DIR}/../../utils")
 
 # Build cpython
+SET(CPYTHON_VERSION 3.8 CACHE STRING "Default version of Cpython to bundle.")
+SET(CPYTHON_VERSION_GIT_TAG 3.8.6 CACHE STRING "Git tag for default version of Cpython to bundle.")
 SET(PYTHON_INSTALL_DIR "${INTERPRETER_DIR}/cpython")
-SET(PYTHON_INC_DIR "${PYTHON_INSTALL_DIR}/include/python3.8")
-SET(PYTHON_INC_DIR "${PYTHON_INSTALL_DIR}/include/python3.8" PARENT_SCOPE)
-SET(PYTHON_LIB "${PYTHON_INSTALL_DIR}/lib/libpython3.8.a")
+SET(PYTHON_INC_DIR "${PYTHON_INSTALL_DIR}/include/python{CPYTHON_VERSION}")
+SET(PYTHON_INC_DIR "${PYTHON_INSTALL_DIR}/include/python{CPYTHON_VERSION}" PARENT_SCOPE)
+SET(PYTHON_LIB "${PYTHON_INSTALL_DIR}/lib/libpython{CPYTHON_VERSION}.a")
 SET(PYTHON_BIN "${PYTHON_INSTALL_DIR}/bin/python3")
 include(ExternalProject)
 ExternalProject_Add(
   cpython
   PREFIX cpython
   GIT_REPOSITORY https://github.com/python/cpython.git
-  GIT_TAG v3.8.6
+  GIT_TAG v{CPYTHON_VERSION_GIT_TAG}
   UPDATE_COMMAND ""
   PATCH_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/cpython_patch.diff
   BUILD_IN_SOURCE True
@@ -47,9 +49,9 @@ include(GoogleTest)
 # the modules in a strange nested path, and then that path is relative to the
 # Cmake ExternalProject root in the cmake build dir.
 ExternalProject_Get_property(cpython SOURCE_DIR)
-SET(PYTHON_MODULE_DIR "${SOURCE_DIR}/build/temp.linux-x86_64-3.8/${SOURCE_DIR}/Modules")
+SET(PYTHON_MODULE_DIR "${SOURCE_DIR}/build/temp.linux-x86_64-{CPYTHON_VERSION}/${SOURCE_DIR}/Modules")
 SET(PYTHON_STDLIB_DIR "${SOURCE_DIR}/Lib")
-SET(PYTHON_STDLIB "${PYTHON_INSTALL_DIR}/lib/libpython_stdlib3.8.a")
+SET(PYTHON_STDLIB "${PYTHON_INSTALL_DIR}/lib/libpython_stdlib{CPYTHON_VERSION}.a")
 # Then we use a hardcoded list of expected module names and include them in our lib
 include("CMakePythonModules.txt")
 ExternalProject_Add_Step(

--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -53,6 +53,12 @@ SET(PYTHON_MODULE_DIR "${SOURCE_DIR}/build/temp.linux-x86_64-{CPYTHON_VERSION}/$
 SET(PYTHON_STDLIB_DIR "${SOURCE_DIR}/Lib")
 SET(PYTHON_STDLIB "${PYTHON_INSTALL_DIR}/lib/libpython_stdlib{CPYTHON_VERSION}.a")
 
+if(${CPYTHON_VERSION} MATCHES "3\.[8-9]")
+  SET(PYTHON_MEM_MODULE "${PYTHON_MODULE_DIR}/_decimal/libmpdec/memory.o")
+elseif(${CPYTHON_VERSION} MATCHES "3\.1[0-1]")
+  SET(PYTHON_MEM_MODULE "${PYTHON_MODULE_DIR}/_decimal/libmpdec/mpalloc.o")
+endif()
+
 # Then we use a hardcoded list of expected module names and include them in our lib
 include("CMakePythonModules.txt")
 ExternalProject_Add_Step(
@@ -60,7 +66,7 @@ ExternalProject_Add_Step(
   archive_stdlib
   DEPENDEES install
   BYPRODUCTS ${PYTHON_STDLIB}
-  COMMAND ar -rc ${PYTHON_STDLIB} ${PYTHON_MODULES}
+  COMMAND ar -rc ${PYTHON_STDLIB} ${PYTHON_MODULES} ${PYTHON_MEM_MODULE}
   VERBATIM
 )
 # Get python typing extension, needed by torch

--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -53,11 +53,6 @@ SET(PYTHON_MODULE_DIR "${SOURCE_DIR}/build/temp.linux-x86_64-{CPYTHON_VERSION}/$
 SET(PYTHON_STDLIB_DIR "${SOURCE_DIR}/Lib")
 SET(PYTHON_STDLIB "${PYTHON_INSTALL_DIR}/lib/libpython_stdlib{CPYTHON_VERSION}.a")
 
-if(${CPYTHON_VERSION} MATCHES "3\.[8-9]")
-  SET(PYTHON_MEM_MODULE "${PYTHON_MODULE_DIR}/_decimal/libmpdec/memory.o")
-elseif(${CPYTHON_VERSION} MATCHES "3\.1[0-1]")
-  SET(PYTHON_MEM_MODULE "${PYTHON_MODULE_DIR}/_decimal/libmpdec/mpalloc.o")
-endif()
 # Then we use a hardcoded list of expected module names and include them in our lib
 include("CMakePythonModules.txt")
 ExternalProject_Add_Step(
@@ -65,7 +60,7 @@ ExternalProject_Add_Step(
   archive_stdlib
   DEPENDEES install
   BYPRODUCTS ${PYTHON_STDLIB}
-  COMMAND ar -rc ${PYTHON_STDLIB} ${PYTHON_MODULES} ${PYTHON_MEM_MODULE}
+  COMMAND ar -rc ${PYTHON_STDLIB} ${PYTHON_MODULES}
   VERBATIM
 )
 # Get python typing extension, needed by torch

--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -52,6 +52,12 @@ ExternalProject_Get_property(cpython SOURCE_DIR)
 SET(PYTHON_MODULE_DIR "${SOURCE_DIR}/build/temp.linux-x86_64-{CPYTHON_VERSION}/${SOURCE_DIR}/Modules")
 SET(PYTHON_STDLIB_DIR "${SOURCE_DIR}/Lib")
 SET(PYTHON_STDLIB "${PYTHON_INSTALL_DIR}/lib/libpython_stdlib{CPYTHON_VERSION}.a")
+
+if(${CPYTHON_VERSION} MATCHES "3\.[8-9]")
+  SET(PYTHON_MEM_MODULE "${PYTHON_MODULE_DIR}/_decimal/libmpdec/memory.o")
+elseif(${CPYTHON_VERSION} MATCHES "3\.1[0-1]")
+  SET(PYTHON_MEM_MODULE "${PYTHON_MODULE_DIR}/_decimal/libmpdec/mpalloc.o")
+endif()
 # Then we use a hardcoded list of expected module names and include them in our lib
 include("CMakePythonModules.txt")
 ExternalProject_Add_Step(
@@ -59,7 +65,7 @@ ExternalProject_Add_Step(
   archive_stdlib
   DEPENDEES install
   BYPRODUCTS ${PYTHON_STDLIB}
-  COMMAND ar -rc ${PYTHON_STDLIB} ${PYTHON_MODULES}
+  COMMAND ar -rc ${PYTHON_STDLIB} ${PYTHON_MODULES} ${PYTHON_MEM_MODULE}
   VERBATIM
 )
 # Get python typing extension, needed by torch

--- a/multipy/runtime/interpreter/CMakePythonModules.txt
+++ b/multipy/runtime/interpreter/CMakePythonModules.txt
@@ -22,7 +22,7 @@ SET(PYTHON_MODULES
   ${PYTHON_MODULE_DIR}/_cursesmodule.o
   ${PYTHON_MODULE_DIR}/_curses_panel.o
   ${PYTHON_MODULE_DIR}/_datetimemodule.o
-  ${PYTHON_MODULE_DIR}/_decimal/_decimal.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/basearith.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/constants.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/context.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/convolute.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/crt.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/difradix2.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/fnt.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/fourstep.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/io.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/mpdecimal.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/numbertheory.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/sixstep.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/transpose.o
+  ${PYTHON_MODULE_DIR}/_decimal/_decimal.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/basearith.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/constants.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/context.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/convolute.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/crt.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/difradix2.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/fnt.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/fourstep.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/io.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/memory.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/mpdecimal.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/numbertheory.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/sixstep.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/transpose.o
   ${PYTHON_MODULE_DIR}/_elementtree.o
   ${PYTHON_MODULE_DIR}/fcntlmodule.o
   ${PYTHON_MODULE_DIR}/grpmodule.o

--- a/multipy/runtime/interpreter/CMakePythonModules.txt
+++ b/multipy/runtime/interpreter/CMakePythonModules.txt
@@ -22,7 +22,7 @@ SET(PYTHON_MODULES
   ${PYTHON_MODULE_DIR}/_cursesmodule.o
   ${PYTHON_MODULE_DIR}/_curses_panel.o
   ${PYTHON_MODULE_DIR}/_datetimemodule.o
-  ${PYTHON_MODULE_DIR}/_decimal/_decimal.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/basearith.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/constants.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/context.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/convolute.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/crt.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/difradix2.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/fnt.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/fourstep.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/io.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/memory.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/mpdecimal.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/numbertheory.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/sixstep.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/transpose.o
+  ${PYTHON_MODULE_DIR}/_decimal/_decimal.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/basearith.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/constants.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/context.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/convolute.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/crt.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/difradix2.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/fnt.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/fourstep.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/io.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/mpdecimal.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/numbertheory.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/sixstep.o ${PYTHON_MODULE_DIR}/_decimal/libmpdec/transpose.o
   ${PYTHON_MODULE_DIR}/_elementtree.o
   ${PYTHON_MODULE_DIR}/fcntlmodule.o
   ${PYTHON_MODULE_DIR}/grpmodule.o


### PR DESCRIPTION
Cpython has had some changes from v3.10 onwards, for example https://fburl.com/diffing/lrcq4gej .

We want to add some conditional inclusions to multipy cmake to support these changes.

Step 1/n : Replace the removed _decimal/libmpdec/memory.o with _decimal/libmpdec/mpalloc.o.