### PR TITLE
Allow compatibility with `torch.storage.TypedStorage`

### DIFF
--- a/multipy/package/package_exporter.py
+++ b/multipy/package/package_exporter.py
@@ -15,6 +15,14 @@ from ._zip_file_torchscript import TorchScriptPackageZipFileWriter
 from .importer import Importer, sys_importer
 from .package_exporter_no_torch import PackageExporter as DefaultPackageExporter
 
+
+# To deal with torch.storage._TypedStorage => torch.storage.TypedStorage renaming
+try:
+    TORCH_STORAGE_CLASS = torch.storage._TypedStorage
+except:
+    TORCH_STORAGE_CLASS = torch.storage.TypedStorage
+
+
 # TODO: fix pytorch master to use PackagingError from the base class then delete below line
 # from .package_exporter_no_torch import PackagingError, EmptyMatchError  # noqa
 
@@ -41,8 +49,9 @@ class PackageExporter(DefaultPackageExporter):
     def persistent_id(self, obj):
         assert isinstance(self.zip_file, TorchScriptPackageZipFileWriter)
         # needed for 'storage' typename which is a way in which torch models are saved
-        if torch.is_storage(obj) or isinstance(obj, torch.storage._TypedStorage):
-            if isinstance(obj, torch.storage._TypedStorage):
+        if torch.is_storage(obj) or isinstance(obj, TORCH_STORAGE_CLASS):
+
+            if isinstance(obj, TORCH_STORAGE_CLASS):
                 # TODO: Once we decide to break serialization FC, we can
                 # remove this case
                 storage = obj._storage

--- a/multipy/package/package_importer.py
+++ b/multipy/package/package_importer.py
@@ -83,9 +83,15 @@ class PackageImporter(DefaultPackageImporter):
             storage = self.loaded_storages[key]
             # TODO: Once we decide to break serialization FC, we can
             # stop wrapping with TypedStorage
-            return torch.storage._TypedStorage(
-                wrap_storage=storage._untyped(), dtype=dtype
-            )
+            try:
+                return torch.storage._TypedStorage(
+                    wrap_storage=storage._untyped(), dtype=dtype
+                )
+            except:
+                return torch.storage.TypedStorage(
+                    wrap_storage=storage.untyped(), dtype=dtype
+                )
+
         return None
 
     @contextmanager


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/82438 renames `torch.storage._TypedStorage` to torch.storage.TypedStorage. This pr allows `multipy.package` to work with both classes in order to be compaitble with nightlies.

Reviewed By: kurman

Differential Revision: D38361266

