### PR TITLE
use ${RUNNER_TEMP} instead of the home directory in CI jobs

### DIFF
--- a/.github/workflows/runtime_nightly.yaml
+++ b/.github/workflows/runtime_nightly.yaml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Setup conda
         run: |
-          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-          bash ~/miniconda.sh -b -p $HOME/miniconda
+          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ${RUNNER_TEMP}/miniconda.sh
+          bash ${RUNNER_TEMP}/miniconda.sh -b -p $HOME/miniconda
 
       - name: setup Path
         run: |

--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Setup conda
         run: |
-          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-          bash ~/miniconda.sh -b -p $HOME/miniconda
+          wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ${RUNNER_TEMP}/miniconda.sh
+          bash ${RUNNER_TEMP}/miniconda.sh -b -p $HOME/miniconda
 
       - name: setup Path
         run: |


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #120

Sometimes on our runners state persists in the home directory. By using `${RUNNER_TEMP}` instead we are a clean directory to put stuff in instead.

Differential Revision: [D38515902](https://our.internmc.facebook.com/intern/diff/D38515902)