### PR TITLE
Fix test_deploy_from_python test

### DIFF
--- a/multipy/runtime/environment.h
+++ b/multipy/runtime/environment.h
@@ -27,11 +27,8 @@ class Environment {
   std::string getZippedArchive(
       const char* zipped_torch_name,
       const std::string& pythonAppDir) {
-    std::string execPath;
-    std::ifstream("/proc/self/cmdline") >> execPath;
-    ElfFile elfFile(execPath.c_str());
     // load the zipped torch modules
-    auto zippedTorchSection = elfFile.findSection(zipped_torch_name);
+    auto zippedTorchSection = searchForSection(zipped_torch_name);
     MULTIPY_CHECK(
         zippedTorchSection.has_value(), "Missing the zipped torch section");
     const char* zippedTorchStart = zippedTorchSection->start;


### PR DESCRIPTION
Summary: [D38337551](https://github.com/pytorch/multipy/pull/111) (https://github.com/pytorch/multipy/commit/ed23d412b1d43f99fb0eda64991c172b6b403fa7) had broken `//multipy/runtime/testdev:test_deploy_from_python` due to a merge conflict. This PR backs out of the faulty merge such that we correctly look for the sections with extra python modules.

Differential Revision: D38717781

