### PR TITLE
ci: multipy runtime tests 3.7-3.10

### DIFF
--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -10,7 +10,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         platform: [ubuntu-18.04]
       fail-fast: false
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
This adds non Python 3.8 versions to our CI

Test plan:

CI