### PR TITLE
multipy/runtime: fix custom ops loading

### DIFF
--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -33,3 +33,7 @@ jobs:
       - name: Test
         run: |
           docker run --rm multipy multipy/runtime/build/test_deploy
+
+      - name: Compat Tests
+        run: |
+          docker run --rm multipy bash -c "pip install -r compat-requirements.txt && multipy/runtime/build/interactive_embedded_interpreter --pyscript multipy/runtime/test_compat.py"

--- a/compat-requirements.txt
+++ b/compat-requirements.txt
@@ -1,0 +1,5 @@
+tokenizers
+torchaudio
+torchvision
+git+https://github.com/facebookresearch/pytorch3d.git
+git+https://github.com/pytorch/torchdynamo.git

--- a/multipy/runtime/interactive_embedded_interpreter.cpp
+++ b/multipy/runtime/interactive_embedded_interpreter.cpp
@@ -33,8 +33,10 @@ int main(int argc, char** argv) {
   auto I = m.acquireOne();
 
   if (FLAGS_pyscript.size() > 0) {
-    auto realpath = I.global("os", "path").attr("expanduser")({FLAGS_pyscript});
-    I.global("runpy", "run_path")({realpath});
+    auto realpath =
+        I.global("os", "path").attr("expanduser")({FLAGS_pyscript}).toIValue();
+    I.global("runpy", "run_path")
+        .callKwargs({realpath}, {{"run_name", "__main__"}});
   } else {
     c10::ArrayRef<torch::deploy::Obj> noArgs;
     I.global("pdb", "set_trace")(noArgs);

--- a/multipy/runtime/interpreter/interpreter_impl.h
+++ b/multipy/runtime/interpreter/interpreter_impl.h
@@ -12,45 +12,6 @@
 
 #include <multipy/runtime/interpreter/Optional.hpp>
 
-/* Torch Deploy intentionally embeds multiple copies of c++ libraries
-   providing python bindings necessary for torch::deploy users in the same
-   process space in order to provide a multi-python environment.  As a result,
-   any exception types defined by these duplicated libraries can't be safely
-   caught or handled outside of the originating dynamic library (.so).
-
-   In practice this means that you must either
-   catch these exceptions inside the torch::deploy API boundary or risk crashing
-   the client application.
-
-   It is safe to throw exception types that are defined once in
-   the context of the client application, such as std::runtime_error,
-   which isn't duplicated in torch::deploy interpreters.
-
-   ==> Use TORCH_DEPLOY_TRY, _SAFE_CATCH_RETHROW around _ALL_ torch::deploy APIs
-
-   For more information, see
-    https://gcc.gnu.org/wiki/Visibility (section on c++ exceptions)
-    or https://stackoverflow.com/a/14364055
-    or
-   https://stackoverflow.com/questions/14268736/symbol-visibility-exceptions-runtime-error
-    note- this may be only a serious problem on versions of gcc prior to 4.0,
-   but still seems worth sealing off.
-
-*/
-#define TORCH_DEPLOY_TRY try {
-#define TORCH_DEPLOY_SAFE_CATCH_RETHROW                                      \
-  }                                                                          \
-  catch (std::exception & err) {                                             \
-    throw std::runtime_error(                                                \
-        std::string(__FILE__) + ":" + std::to_string(__LINE__) +             \
-        ": Exception Caught inside torch::deploy embedded library: \n" +     \
-        err.what());                                                         \
-  }                                                                          \
-  catch (...) {                                                              \
-    throw std::runtime_error(                                                \
-        std::string(__FILE__) + ":" + std::to_string(__LINE__) +             \
-        ": Unknown Exception Caught inside torch::deploy embedded library"); \
-  }
 namespace torch {
 namespace deploy {
 
@@ -147,46 +108,32 @@ struct InterpreterImpl {
 // source file that would need to exist it both the libinterpreter.so and then
 // the libtorchpy library.
 inline at::IValue Obj::toIValue() const {
-  TORCH_DEPLOY_TRY
   return interaction_->toIValue(*this);
-  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
 inline Obj Obj::operator()(at::ArrayRef<Obj> args) {
-  TORCH_DEPLOY_TRY
   return interaction_->call(*this, args);
-  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
 inline Obj Obj::operator()(at::ArrayRef<at::IValue> args) {
-  TORCH_DEPLOY_TRY
   return interaction_->call(*this, args);
-  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
 inline Obj Obj::callKwargs(
     std::vector<at::IValue> args,
     std::unordered_map<std::string, c10::IValue> kwargs) {
-  TORCH_DEPLOY_TRY
   return interaction_->callKwargs(*this, std::move(args), std::move(kwargs));
-  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 inline Obj Obj::callKwargs(
     std::unordered_map<std::string, c10::IValue> kwargs) {
-  TORCH_DEPLOY_TRY
   return interaction_->callKwargs(*this, std::move(kwargs));
-  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 inline bool Obj::hasattr(const char* attr) {
-  TORCH_DEPLOY_TRY
   return interaction_->hasattr(*this, attr);
-  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
 inline Obj Obj::attr(const char* attr) {
-  TORCH_DEPLOY_TRY
   return interaction_->attr(*this, attr);
-  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
 } // namespace deploy

--- a/multipy/runtime/test_compat.py
+++ b/multipy/runtime/test_compat.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+
+class TestCompat(unittest.TestCase):
+    def test_torchvision(self):
+        import torchvision  # noqa: F401
+
+    @unittest.skip("torchaudio has a symbol error")
+    def test_torchaudio(self):
+        import torchaudio  # noqa: F401
+
+    def test_pytorch3d(self):
+        import pytorch3d  # noqa: F401
+
+    def test_hf_tokenizers(self):
+        import tokenizers  # noqa: F401
+
+    def test_torchdynamo_eager(self):
+        import torchdynamo
+
+        @torchdynamo.optimize("eager")
+        def fn(x, y):
+            a = torch.cos(x)
+            b = torch.sin(y)
+            return a + b
+
+        fn(torch.randn(10), torch.randn(10))
+
+    @unittest.skip("ofi segfaults")
+    def test_torchdynamo_ofi(self):
+        import torchdynamo
+
+        @torchdynamo.optimize("ofi")
+        def fn(x, y):
+            a = torch.cos(x)
+            b = torch.sin(y)
+            return a + b
+
+        fn(torch.randn(10), torch.randn(10))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/multipy/runtime/test_deploy.cpp
+++ b/multipy/runtime/test_deploy.cpp
@@ -53,6 +53,7 @@ TEST(TorchpyTest, InitManagerBasic) {
   ASSERT_EQ(m.countRegisteredModuleSources(), 1);
 }
 
+#ifdef FBCODE_CAFFE2
 TEST(TorchpyTest, LoadLibrary) {
   torch::deploy::InterpreterManager m(1);
   torch::deploy::Package p = m.loadPackage(
@@ -60,6 +61,7 @@ TEST(TorchpyTest, LoadLibrary) {
   auto model = p.loadPickle("fn", "fn.pkl");
   model({});
 }
+#endif
 
 TEST(TorchpyTest, InitTwice) {
   { torch::deploy::InterpreterManager m(2); }
@@ -208,9 +210,6 @@ TEST(TorchpyTest, ErrorsReplicatingObj) {
 TEST(TorchpyTest, ThrowsSafely) {
   // See explanation in deploy.h
   torch::deploy::InterpreterManager manager(3);
-  // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
-  EXPECT_THROW(manager.loadPackage("some garbage path"), std::runtime_error);
-
   torch::deploy::Package p = manager.loadPackage(path("SIMPLE", simple));
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   EXPECT_THROW(p.loadPickle("some other", "garbage path"), std::runtime_error);


### PR DESCRIPTION
This fixes custom ops loading by changing the `sys.executable` to something other than `torch_deploy` to disable most of the pytorch deploy workarounds. We resolve this by adding in a mocked module on `_meta_registrations` to prevent it form loading and crashing.

This also reworks interactive_embedded_interpreter and how we catch exceptions to be able to catch the SystemExit exception and behave correctly. We remove the TORCH_DEPLOY_TRY methods from deploy.cpp/interpreter_impl.h and move them into the intepreter in interpreter_impl.cpp where we can inspect into the python exceptions safely before rethrowing.

Test plan:

Add test_compat.py to CI