### PR TITLE
Migrate torchrec/hpc/predictor/mulitray from torch::deploy to multipy (#589)

### DIFF
--- a/multipy/package/importer.py
+++ b/multipy/package/importer.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import importlib
+import inspect
 from abc import ABC, abstractmethod
 from pickle import (  # type: ignore[attr-defined]  # type: ignore[attr-defined]
     _getattribute,
@@ -212,6 +213,15 @@ class OrderedImporter(Importer):
         return module.__file__ is None
 
     def import_module(self, module_name: str) -> ModuleType:
+        def check_if_torch_package(obj):
+            for cls in inspect.getmro(type(obj)):
+                if (
+                    cls.__module__ == "torch.package.importer"
+                    and cls.__name__ == "Importer"
+                ):
+                    return True
+            return False
+
         last_err = None
         for importer in self._importers:
             # allow for torch.package bc

--- a/multipy/package/package_exporter_no_torch.py
+++ b/multipy/package/package_exporter_no_torch.py
@@ -10,6 +10,8 @@ import io
 import linecache
 import pickletools
 import platform
+
+import sys
 import types
 from collections import defaultdict, OrderedDict
 from dataclasses import dataclass
@@ -523,7 +525,9 @@ class PackageExporter:
             # and continue.
             filename = getattr(module_obj, "__file__", None)
             error_context = None
-            if filename is None:
+            if module_name in sys.builtin_module_names:
+                pass
+            elif filename is None:
                 packaging_error = PackagingErrorReason.NO_DUNDER_FILE
             elif filename.endswith(tuple(importlib.machinery.EXTENSION_SUFFIXES)):
                 if self.auto_extern_c_extension_modules:


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/589

We are creating a new repo called `fbcode/multipy` to house `torch.package` and `torch::deploy` code.

This diff migrates over `//caffe2/torch/csrc/deploy:xxx` usages over to `//caffe2/multipy/runtime` which is the new repo we are moving `torch::deploy` code to.

Differential Revision: D37358185

