### PR TITLE
multipy/runtime: fix versioned symbol loading (ex torchaudio)

### DIFF
--- a/multipy/runtime/loader.cpp
+++ b/multipy/runtime/loader.cpp
@@ -70,7 +70,8 @@ namespace torch {
 namespace deploy {
 
 #define DEPLOY_ERROR(msg_fmt, ...) \
-  throw DeployLoaderError(fmt::format(msg_fmt, ##__VA_ARGS__))
+  throw DeployLoaderError(         \
+      fmt::format("{}:{}: " msg_fmt, __FILE__, __LINE__, ##__VA_ARGS__))
 
 #define DEPLOY_CHECK(cond, fmt, ...)  \
   if (!(cond)) {                      \
@@ -286,8 +287,10 @@ struct __attribute__((visibility("hidden"))) SystemLibraryImpl
   SystemLibraryImpl(void* handle, bool steal)
       : handle_(handle), own_handle_(steal && handle != RTLD_DEFAULT) {}
 
-  multipy::optional<Elf64_Addr> sym(const char* name) const override {
-    void* r = dlsym(handle_, name);
+  multipy::optional<Elf64_Addr> sym(
+      const char* name,
+      const char* version = nullptr) const override {
+    void* r = version ? dlvsym(handle_, name, version) : dlsym(handle_, name);
     if (!r) {
       return multipy::nullopt;
     }
@@ -390,6 +393,9 @@ struct ElfDynamicInfo {
   size_t n_plt_rela_ = 0;
   Elf64_Rela* rela_ = nullptr;
   size_t n_rela_ = 0;
+  Elf64_Versym* versym_ = nullptr;
+  Elf64_Verneed* verneed_ = nullptr;
+  size_t n_verneed_ = 0;
   linker_ctor_function_t init_func_ = nullptr;
   linker_ctor_function_t* init_array_ = nullptr;
   linker_dtor_function_t fini_func_ = nullptr;
@@ -446,6 +452,16 @@ struct ElfDynamicInfo {
           break;
         case DT_RELASZ:
           n_rela_ = value / sizeof(Elf64_Rela);
+          break;
+
+        case DT_VERSYM:
+          versym_ = (Elf64_Versym*)addr;
+          break;
+        case DT_VERNEED:
+          verneed_ = (Elf64_Verneed*)addr;
+          break;
+        case DT_VERNEEDNUM:
+          n_verneed_ = value;
           break;
 
         case DT_INIT:
@@ -970,21 +986,51 @@ struct __attribute__((visibility("hidden"))) CustomLibraryImpl
         return (Elf64_Addr)__cxa_thread_atexit_impl;
       }
     }
+
+    // Get the version string if required by the symbol.
+    // https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA.junk/symversion.html
+    const char* version = nullptr;
+    Elf64_Versym versym = 0;
+    if (dyninfo_.versym_) {
+      versym = dyninfo_.versym_[r_sym];
+      // 0=local, 1=global, >2=version
+      if (versym >= 2) {
+        auto* verneed = dyninfo_.verneed_;
+        for (auto i = 0; i < dyninfo_.n_verneed_; i++) {
+          Elf64_Vernaux* aux =
+              (Elf64_Vernaux*)((unsigned long)verneed + verneed->vn_aux);
+          for (auto j = 0; j < verneed->vn_cnt; j++) {
+            if (aux->vna_other == versym) {
+              version = dyninfo_.get_string(aux->vna_name);
+              break;
+            }
+            aux = (Elf64_Vernaux*)((unsigned long)aux + aux->vna_next);
+          }
+          verneed = (Elf64_Verneed*)((unsigned long)verneed + verneed->vn_next);
+        }
+      }
+    }
+
     for (const auto& sys_lib : symbol_search_path_) {
-      auto r = sys_lib->sym(sym_name);
+      auto r = sys_lib->sym(sym_name, version);
       if (r) {
         return r;
       }
     }
-    auto r = sym(sym_name);
+    auto r = sym(sym_name, version);
     if (r) {
       return r;
     }
     if (ELF64_ST_BIND(sym_st.st_info) != STB_WEAK) {
+      if (!version) {
+        version = "nullptr";
+      }
       DEPLOY_ERROR(
-          "{}: '{}' symbol not found in ElfFile lookup",
+          "{}: '{}' symbol not found in ElfFile lookup, version {} ({})",
           name_.c_str(),
-          sym_name);
+          sym_name,
+          version,
+          versym);
     }
     return multipy::nullopt;
   }
@@ -1170,7 +1216,11 @@ struct __attribute__((visibility("hidden"))) CustomLibraryImpl
     f(argc_, argv_, environ);
   }
 
-  multipy::optional<Elf64_Addr> sym(const char* name) const override {
+  multipy::optional<Elf64_Addr> sym(
+      const char* name,
+      const char* version = nullptr) const override {
+    // We ignore version since this is looking up symbols in this file and there
+    // should only be one.
     return dyninfo_.sym(name);
   }
 

--- a/multipy/runtime/loader.h
+++ b/multipy/runtime/loader.h
@@ -25,7 +25,9 @@ struct TLSIndex {
 
 struct SymbolProvider {
   SymbolProvider() = default;
-  virtual multipy::optional<Elf64_Addr> sym(const char* name) const = 0;
+  virtual multipy::optional<Elf64_Addr> sym(
+      const char* name,
+      const char* version = nullptr) const = 0;
   virtual multipy::optional<TLSIndex> tls_sym(const char* name) const = 0;
   SymbolProvider(const SymbolProvider&) = delete;
   SymbolProvider& operator=(const SymbolProvider&) = delete;

--- a/multipy/runtime/test_compat.py
+++ b/multipy/runtime/test_compat.py
@@ -13,7 +13,6 @@ class TestCompat(unittest.TestCase):
     def test_torchvision(self):
         import torchvision  # noqa: F401
 
-    @unittest.skip("torchaudio has a symbol error")
     def test_torchaudio(self):
         import torchaudio  # noqa: F401
 


### PR DESCRIPTION
This fixes issues where a dynamically loaded library (such as for torchaudio) has a dependency on a specific symbol version. TorchAudio requires `__log_finite` which is not a default symbol thus runtime fails to find it.

This updates the loader to parse the DT_VERNEED and DT_VERSYM entries in the ELF dynamic table to grab the required version string and pass it to `dlvsym`.

* torchaudio.so version info: https://gist.github.com/d4l3k/8724b0f3b1011a02287b825bed199486
* libm.so.6 `__log_finite` symbol: https://gist.github.com/d4l3k/3b4d9cd376338ec48109032dade2cdb7
* Symbol Versioning docs: https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA.junk/symversion.html#VERNEEDFIG

Test plan:

Enabled torchaudio in `test_compat.py`.