### PR TITLE
multipy: fix unity_demo

### DIFF
--- a/multipy/runtime/interpreter/import_find_sharedfuncptr.cpp
+++ b/multipy/runtime/interpreter/import_find_sharedfuncptr.cpp
@@ -53,6 +53,7 @@ extern "C" dl_funcptr _PyImport_FindSharedFuncptr(
   // that itself gets unloaded.
   loaded_files_.emplace_back(CustomLibrary::create(pathname, 1, args));
   CustomLibrary& lib = *loaded_files_.back();
+  assert(deploy_self);
   lib.add_search_library(SystemLibrary::create(deploy_self));
   lib.add_search_library(SystemLibrary::create());
   for (auto f : search_files_) {

--- a/multipy/runtime/loader.cpp
+++ b/multipy/runtime/loader.cpp
@@ -267,6 +267,10 @@ static void* local__tls_get_addr(TLSIndex* idx);
 __attribute__((noinline)) void __deploy_register_code() {
   std::cout << ""; // otherwise the breakpoint doesn't get hit, not sure if
                    // there is a more stable way of doing this.
+  unsigned i;
+  for (i = 0; i < 10; i++) {
+    __asm__ volatile("" : "+g"(i) : :);
+  }
 };
 
 struct DeployModuleInfo {

--- a/multipy/runtime/remove_dt_needed.cpp
+++ b/multipy/runtime/remove_dt_needed.cpp
@@ -33,7 +33,7 @@ int main(int argc, const char** argv) {
     return 1;
   }
   const char* filename = argv[1];
-  int fd_ = open(filename, O_RDWR);
+  int fd_ = open(filename, O_RDONLY);
   CHECK(fd_ != -1, "failed to open {}: {}", filename, strerror(errno));
   struct stat s = {0};
   if (-1 == fstat(fd_, &s)) {


### PR DESCRIPTION
Summary:
This fixes the unity_demo which requires `intepreter_all` variant internally due to the custom loading.

* adds back sharedfuncptr code to target
* added more complexity to `__deploy_register_code` to avoid it getting optimized out
* switched remove_dt_needed to only use read since some build systems limit files to read only

Differential Revision: D39193272

