### PR TITLE
Modify dockerfile to use latest cmake on ubuntu18.04 docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
         build-essential \
         ca-certificates \
         ccache \
-        cmake \
         curl \
         wget \
         git \
@@ -33,10 +32,16 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
         tix-dev \
         libgtest-dev \
         tk-dev \
-        libsqlite3-dev && \
+        libsqlite3-dev \
+        apt-transport-https \
+        ca-certificates \
+        gnupg \
+        software-properties-common && \
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
+        apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
         echo "deb http://security.ubuntu.com/ubuntu focal-security main" >> /etc/apt/sources.list && \
         apt update && \
-        apt install -y binutils && \
+        apt install -y binutils cmake && \
     rm -rf /var/lib/apt/lists/*
 RUN /usr/sbin/update-ccache-symlinks
 RUN mkdir /opt/ccache && ccache --set-config=cache_dir=/opt/ccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Mini
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
-    /opt/conda/bin/conda install -y python=${PYTHON_VERSION} cmake mkl mkl-include conda-build pyyaml numpy ipython && \
+    /opt/conda/bin/conda install -y python=${PYTHON_VERSION} mkl mkl-include conda-build pyyaml numpy ipython && \
     /opt/conda/bin/conda install -y -c conda-forge libpython-static=${PYTHON_VERSION} && \
     /opt/conda/bin/conda install -y pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch-nightly && \
     /opt/conda/bin/conda clean -ya


### PR DESCRIPTION
Summary: As title; by default the image seems to have cmake3.10. This change should update cmake to latest version (3.19+ ideally).

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: