### PR TITLE
Ignore return value of function declared with 'warn_unused_result'

### DIFF
--- a/multipy/runtime/environment.h
+++ b/multipy/runtime/environment.h
@@ -66,7 +66,7 @@ class Environment {
   }
   virtual ~Environment() {
     auto rmCmd = "rm -rf " + extraPythonLibrariesDir_;
-    system(rmCmd.c_str());
+    (void)system(rmCmd.c_str());
   }
   virtual void configureInterpreter(Interpreter* interp) = 0;
   virtual const std::vector<std::string>& getExtraPythonPaths() {


### PR DESCRIPTION
Summary:
Ignore return value of function declared with 'warn_unused_result'

Addresses the following build failure that we get on some of our internal build environments:
caffe2/torch/csrc/deploy/environment.h:60:5: error: ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result] system(rmCmd.c_str());

When building locally on a dev server, this compiles just fine, but when building in service lab produced the above build error.

Reviewed By: PaliC

Differential Revision: D39363916

