### PR TITLE
Split out compat tests from CI

### DIFF
--- a/.github/workflows/runtime_compat_tests.yaml
+++ b/.github/workflows/runtime_compat_tests.yaml
@@ -1,8 +1,12 @@
-name: Multipy runtime nightly test (without compat) + release
+name: Multipy runtime compat tests
 
 on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   unittest:
@@ -28,20 +32,6 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: docker build -t multipy --progress=plain --build-arg PYTHON_VERSION=${{ matrix.python-version }} .
 
-      - name: Test
+      - name: Compat Tests
         run: |
-          docker run --rm multipy multipy/runtime/build/test_deploy
-
-      - name: Create Tarball
-        run: |
-          docker cp $(docker run -d multipy):/opt/dist/multipy .
-          tar -czvf multipy_runtime_python${{ matrix.python-version }}.tar.gz multipy/
-
-      - name: Update nightly release
-        uses: pyTooling/Actions/releaser@main
-        with:
-          tag: nightly-runtime-python${{ matrix.python-version }}
-          rm: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: |
-            multipy_runtime_python${{ matrix.python-version }}.tar.gz
+          docker run --rm multipy bash -c "pip install -r compat-requirements.txt && multipy/runtime/build/interactive_embedded_interpreter --pyscript multipy/runtime/test_compat.py"

--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -33,7 +33,3 @@ jobs:
       - name: Test
         run: |
           docker run --rm multipy multipy/runtime/build/test_deploy
-
-      - name: Compat Tests
-        run: |
-          docker run --rm multipy bash -c "pip install -r compat-requirements.txt && multipy/runtime/build/interactive_embedded_interpreter --pyscript multipy/runtime/test_compat.py"


### PR DESCRIPTION
Summary: Currently our compat tests are broken due to some problems with functorch. This PR splits out the compat and native tests primarily for unblocking releases. For DevX purposes this speeds up testing slightly as nightly and compat tests now happen in parallel.

Differential Revision: D39513242

