### PR TITLE
Make `loader.cpp` compatible with glibc <= 2.17

### DIFF
--- a/multipy/runtime/loader.cpp
+++ b/multipy/runtime/loader.cpp
@@ -50,6 +50,7 @@
 #include <climits>
 #include <cstdint>
 #include <cstring>
+#include <cxxabi.h>
 #include <functional>
 #include <iostream>
 #include <sstream>
@@ -243,9 +244,6 @@ struct EH_Frame_HDR {
 // It is passed a pointer to an object of the same shape as TLSEntry
 // with the module_id and offset.
 extern "C" void* __tls_get_addr(void*);
-
-extern "C" int
-__cxa_thread_atexit_impl(void (*dtor)(void*), void* obj, void* dso_symbol);
 
 // This object performs TLS emulation for modules not loaded by dlopen.
 // Normally modules have a module_id that is used as a key in libc for the
@@ -987,7 +985,7 @@ struct __attribute__((visibility("hidden"))) CustomLibraryImpl
         return (Elf64_Addr)local__tls_get_addr;
       }
       if (strcmp(sym_name, "__cxa_thread_atexit") == 0) {
-        return (Elf64_Addr)__cxa_thread_atexit_impl;
+        return (Elf64_Addr)__cxxabiv1::__cxa_thread_atexit;
       }
     }
 
@@ -1242,7 +1240,7 @@ struct __attribute__((visibility("hidden"))) CustomLibraryImpl
     void* start = pthread_getspecific(tls_key_);
     if (!start) {
       start = malloc(tls_mem_size_);
-      __cxa_thread_atexit_impl(free, start, &__dso_handle);
+      __cxxabiv1::__cxa_thread_atexit(free, start, &__dso_handle);
       memcpy(start, tls_initalization_image_, tls_file_size_);
       memset(
           (void*)((const char*)start + tls_file_size_),


### PR DESCRIPTION
In the current `loader.cpp`, the symbol `__cxa_thread_atexit_impl` is introduced by `extern "C"`: https://github.com/pytorch/multipy/blob/main/multipy/runtime/loader.cpp#L247-L248

However, this symbol is exposed in libc.so.6 only when glibc version is >=2.18. With old glibc, compile fails.

In this PR, the problem is solved by replacing `__cxa_thread_atexit_impl` with `__cxxabiv1::__cxa_thread_atexit`.

The function `__cxxabiv1::__cxa_thread_atexit` is a simple wrapper of `__cxa_thread_atexit_impl` and does exactly the same job: https://github.com/gcc-mirror/gcc/blob/16e2427f50c208dfe07d07f18009969502c25dc8/libstdc%2B%2B-v3/libsupc%2B%2B/atexit_thread.cc#L41-L47. The function is declared in the `cxxabi.h`. So we can use it by `include <cxxabi.h>` and the code no longer depends on glibc version.