### PR TITLE
multipy/runtime: mock _decomp

### DIFF
--- a/multipy/runtime/interpreter/interpreter_impl.cpp
+++ b/multipy/runtime/interpreter/interpreter_impl.cpp
@@ -125,8 +125,16 @@ import importlib.abc
 import linecache
 from zipfile import ZipFile
 
+class DummyMultiPyModule:
+    def __getattr__(self, key):
+        return self
+
+    def __call__(self, *args, **kwargs):
+        return self
+
 # Disable Python library registration since it's not compatible with multipy.
-sys.modules["torch._meta_registrations"] = object
+sys.modules["torch._meta_registrations"] = DummyMultiPyModule()
+sys.modules["torch._decomp"] = DummyMultiPyModule()
 
 class RegisterModuleImporter(importlib.abc.InspectLoader):
     def __init__(self, find_module_source):
@@ -160,6 +168,8 @@ class RegisterModuleImporter(importlib.abc.InspectLoader):
 # print("modules:", sys.modules)
 
 import torch # has to be done serially otherwise things will segfault
+torch._decomp = DummyMultiPyModule()
+
 import multipy.utils
 try:
   import torch.version # for some reason torch doesn't import this and cuda fails?


### PR DESCRIPTION
Fixes regression introduced in #84976

https://github.com/pytorch/multipy/actions/runs/3070434091/jobs/4960152377

This mocks out the whole _decomp module -- I tried just avoiding the _decomp import but torchdynamo/functorch will import it causing issues

Test plan:

CI