### PR TITLE
Remove functorch from compat-requirements.txt

### DIFF
--- a/compat-requirements.txt
+++ b/compat-requirements.txt
@@ -3,4 +3,3 @@ torchaudio
 torchvision
 git+https://github.com/facebookresearch/pytorch3d.git
 git+https://github.com/pytorch/torchdynamo.git
-git+https://github.com/pytorch/pytorch.git#subdirectory=functorch


### PR DESCRIPTION
We've changed how functorch is installed -- functorch is now included as a part of the pytorch nightly binary. Soon the old way of installing functorch (which is currently a no-op today) will go away, so this PR updates the install command in multipy.

Test Plan:
- wait for CI