### PR TITLE
multipy: disable torch.Library via env

### DIFF
--- a/compat-requirements.txt
+++ b/compat-requirements.txt
@@ -3,4 +3,3 @@ torchaudio
 torchvision
 git+https://github.com/facebookresearch/pytorch3d.git
 git+https://github.com/pytorch/torchdynamo.git
-git+https://github.com/pytorch/pytorch.git#subdirectory=functorch

--- a/multipy/runtime/deploy.cpp
+++ b/multipy/runtime/deploy.cpp
@@ -53,6 +53,8 @@ InterpreterManager::InterpreterManager(
     : resources_(nInterp) {
   // disable GIL deadlock detection if it's not set already
   setenv("TORCH_DISABLE_DEADLOCK_DETECTION", "1", /*overwrite*/ 0);
+  // disable prims/torch.Library support
+  setenv("PYTORCH_DISABLE_LIBRARY", "1", /*overwrite*/ 0);
 
   for (const auto i : c10::irange(nInterp)) {
     instances_.emplace_back(this, env);

--- a/multipy/runtime/test_compat.py
+++ b/multipy/runtime/test_compat.py
@@ -22,6 +22,7 @@ class TestCompat(unittest.TestCase):
     def test_hf_tokenizers(self):
         import tokenizers  # noqa: F401
 
+    @unittest.skip("torch.Library is not supported")
     def test_torchdynamo_eager(self):
         import torchdynamo
 
@@ -33,6 +34,7 @@ class TestCompat(unittest.TestCase):
 
         fn(torch.randn(10), torch.randn(10))
 
+    @unittest.skip("torch.Library is not supported")
     def test_torchdynamo_ofi(self):
         import torchdynamo
 


### PR DESCRIPTION
This disables `torch.Library` using the new PYTORCH_DISABLE_LIBRARY environment variable. https://github.com/pytorch/pytorch/commit/02f654abca89760ea8004d50702410aceb2296f4

This also disables dynamo compat test since it's incompatible

Fixes:
https://github.com/pytorch/multipy/actions/runs/3085738909/jobs/4989367737

Test plan:
CI