### PR TITLE
Replace IValue::toString()->string() with IValue::toStringRef()

### DIFF
--- a/multipy/runtime/test_deploy.cpp
+++ b/multipy/runtime/test_deploy.cpp
@@ -500,7 +500,7 @@ TEST(TorchpyTest, TestPyYAML) {
   EXPECT_EQ(1, load.attr("__getitem__")({"a"}).toIValue().toInt());
 
   auto dump = I.global("yaml", "dump")({load});
-  EXPECT_EQ(kDocument, dump.toIValue().toString()->string());
+  EXPECT_EQ(kDocument, dump.toIValue().toStringRef());
 }
 #endif
 

--- a/multipy/runtime/test_deploy_gpu.cpp
+++ b/multipy/runtime/test_deploy_gpu.cpp
@@ -137,6 +137,6 @@ TEST(TorchpyTest, TestPyYAML) {
   EXPECT_EQ(1, load.attr("__getitem__")({"a"}).toIValue().toInt());
 
   auto dump = I.global("yaml", "dump")({load});
-  EXPECT_EQ(kDocument, dump.toIValue().toString()->string());
+  EXPECT_EQ(kDocument, dump.toIValue().toStringRef());
 }
 #endif


### PR DESCRIPTION
Summary: ATT: for pytorch/multiply

Differential Revision: D39707244

