### PR TITLE
[Setup.py] [1/n] Refactor py versioning in package tests yaml.

### DIFF
--- a/.github/workflows/package_tests.yaml
+++ b/.github/workflows/package_tests.yaml
@@ -17,9 +17,8 @@ jobs:
         python-minor-version: [7,8,9]
         platform: [ubuntu-18.04]
         include:
-          - python-major-version: 3
-          - python-minor-version: 9
-          - platform: macos-latest
+          - python-version: 3.9
+            platform: macos-latest
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/package_tests.yaml
+++ b/.github/workflows/package_tests.yaml
@@ -13,18 +13,21 @@ jobs:
   unittest:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-major-version: [3]
+        python-minor-version: [7,8,9,10]
         platform: [ubuntu-18.04]
         include:
-          - python-version: 3.9
-            platform: macos-latest
+          - platform: macos-latest
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: Set Python Version
+        run: |
+          echo "python-version=${{ matrix.python-major-version }}.${{ matrix.python-minor-version }}" >> $GITHUB_ENV
+      - name: Setup Python ${{ env.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.python-version }}
           architecture: x64
       - name: Checkout MultiPy
         uses: actions/checkout@v2

--- a/.github/workflows/package_tests.yaml
+++ b/.github/workflows/package_tests.yaml
@@ -14,10 +14,11 @@ jobs:
     strategy:
       matrix:
         python-major-version: [3]
-        python-minor-version: [7,8,9,10]
+        python-minor-version: [7,8,9]
         platform: [ubuntu-18.04]
         include:
-          - python-version: 3.9
+          - python-major-version: 3
+          - python-minor-version: 9
           - platform: macos-latest
       fail-fast: false
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/package_tests.yaml
+++ b/.github/workflows/package_tests.yaml
@@ -17,7 +17,8 @@ jobs:
         python-minor-version: [7,8,9]
         platform: [ubuntu-18.04]
         include:
-          - python-version: 3.9
+          - python-major-version: 3
+            python-minor-version: 9
             platform: macos-latest
       fail-fast: false
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/package_tests.yaml
+++ b/.github/workflows/package_tests.yaml
@@ -17,6 +17,7 @@ jobs:
         python-minor-version: [7,8,9,10]
         platform: [ubuntu-18.04]
         include:
+          - python-version: 3.9
           - platform: macos-latest
       fail-fast: false
     runs-on: ${{ matrix.platform }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,3 @@ black==22.3.0
 usort==1.0.2
 flake8==3.9.0
 expecttest
-setuptools<60

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,4 @@ black==22.3.0
 usort==1.0.2
 flake8==3.9.0
 expecttest
+setuptools<60

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,8 @@ if __name__ == "__main__":
                 # latest numpy doesn't support 3.7
                 "numpy<=1.21.6",
             ],
-            ':python_version >= "3.10"': [
-                "setuptools < 60",
+            ':python_version < "3.12"': [
+                "setuptools<60.0",
             ],
         },
         # PyPI package information.

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,9 @@ if __name__ == "__main__":
                 # latest numpy doesn't support 3.7
                 "numpy<=1.21.6",
             ],
+            ':python_version >= "3.10"': [
+                "setuptools < 60",
+            ],
         },
         # PyPI package information.
         classifiers=[


### PR DESCRIPTION
Summary: We want to be able to pip install multipy runtime via setup.py. To do so, we need to install dependencies and use version numbers in the same way as runtime/nightly tests. This PR includes the py versioning changes to package tests' YAML.

Test Plan: No changes to functionality with this PR.

Reviewers:

Subscribers:

Tasks:

Tags: