### PR TITLE
[Dockerfile] Replace apt-key in Dockerfile with gpg.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ RUN --mount=type=cache,id=apt-dev,target=/var/cache/apt \
         software-properties-common \
         python-pip \
         python3-pip && \
-        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && \
-        apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
-        echo "deb http://security.ubuntu.com/ubuntu focal-security main" >> /etc/apt/sources.list && \
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor -o /usr/share/keyrings/magic-key.gpg && \
+        echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/magic-key.gpg] https://apt.kitware.com/ubuntu/ bionic main" | tee -a /etc/apt/sources.list && \
+        echo "deb http://security.ubuntu.com/ubuntu focal-security main" | tee -a /etc/apt/sources.list && \
         apt update && \
         apt install -y binutils cmake && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Summary: 
apt-key is getting deprecated in newer ubuntus; although we are using an older version for our docker base image, it's better to avoid using legacy stuff.
Replacing the apt-key and apt-add repo updates with explicit gpg conversion (PGP to GPG) and add to sources.list.

Test Plan: No functionality changes

Reviewers:

Subscribers:

Tasks:

Tags: