### PR TITLE
[Setup.py] [0.5/n] Move torch and setuptools to build dependencies.

### DIFF
--- a/.github/pyproject.toml
+++ b/.github/pyproject.toml
@@ -1,2 +1,5 @@
+[build-system]
+requires = ["torch >= 1.11.0", "setuptools < 60.0"]
+
 [tool.usort]
 first_party_detection = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 dataclasses
 expecttest
 PyYAML==6.0
-torch>=1.11.0
 numpy

--- a/setup.py
+++ b/setup.py
@@ -75,9 +75,6 @@ if __name__ == "__main__":
                 # latest numpy doesn't support 3.7
                 "numpy<=1.21.6",
             ],
-            ':python_version < "3.12"': [
-                "setuptools<60.0",
-            ],
         },
         # PyPI package information.
         classifiers=[


### PR DESCRIPTION
Summary: Currently torch is specified in the install_requires list, which makes it an install dependency. With pip install -related changes for runtime we need this to be a build-time dependency instead.

Test Plan: Verify `python -m pip install .` works.

Reviewers:

Subscribers:

Tasks:

Tags: