### PR TITLE
Load extra_files of package in cpp (needed for saved requests and warmup) (#83882)

### DIFF
--- a/multipy/runtime/deploy.h
+++ b/multipy/runtime/deploy.h
@@ -257,6 +257,32 @@ struct TORCH_API Package {
     return I.createMovable(loaded);
   }
 
+#ifdef FBCODE_CAFFE2
+  std::string loadText(const std::string& packageName, const std::string& key) {
+    auto I = acquireSession();
+    return I.self.attr("load_text")({packageName, key})
+        .toIValue()
+        .toStringRef();
+  }
+
+  // Example usage:
+  //  in python:
+  //    with PackageExporter(output) as pe:
+  //        pe.save_binary("extra_files", "greeting", b'hello')
+  //  in cpp:
+  //    std::string decodedBinary = package->loadBinary("extra_files",
+  //    "greeting").toStringRef();
+  //    std::cout << decodedBinary; --> outputs "hello"
+  std::string loadBinary(
+      const std::string& packageName,
+      const std::string& key) {
+    auto I = acquireSession();
+    return I.self.attr("load_binary")({packageName, key})
+        .toIValue()
+        .toStringRef();
+  }
+#endif
+
   InterpreterSession acquireSession() {
     auto I = manager_->acquireOne();
     I.self =

--- a/multipy/runtime/example/generate_examples.py
+++ b/multipy/runtime/example/generate_examples.py
@@ -56,7 +56,15 @@ def generate_fx_example():
     model_jit.save(str(p / (name + "_jit")))
 
 
-def save(name, model, model_jit=None, eg=None, featurestore_meta=None):
+def save(
+    name,
+    model,
+    model_jit=None,
+    eg=None,
+    featurestore_meta=None,
+    text_in_extra_file=None,
+    binary_in_extra_file=None,
+):
     with PackageExporter(str(p / name)) as e:
         e.mock("iopath.**")
         e.intern("**")
@@ -67,6 +75,10 @@ def save(name, model, model_jit=None, eg=None, featurestore_meta=None):
             # TODO(whc) can this name come from buck somehow,
             # so it's consistent with predictor_config_constants::METADATA_FILE_NAME()?
             e.save_text("extra_files", "metadata.json", featurestore_meta)
+        if text_in_extra_file:
+            e.save_text("extra_files", "text", text_in_extra_file)
+        if binary_in_extra_file:
+            e.save_binary("extra_files", "binary", binary_in_extra_file)
 
     if model_jit:
         model_jit.save(str(p / (name + "_jit")))
@@ -91,7 +103,14 @@ if __name__ == "__main__":
     save("resnet", resnet, resnet_traced, (resnet_eg,))
 
     simple = Simple(10, 20)
-    save("simple", simple, torch.jit.script(simple), (torch.rand(10, 20),))
+    save(
+        name="simple",
+        model=simple,
+        model_jit=torch.jit.script(simple),
+        eg=(torch.rand(10, 20),),
+        text_in_extra_file="hello",
+        binary_in_extra_file=b"hello",
+    )
 
     multi_return = MultiReturn()
     save(

--- a/multipy/runtime/test_deploy.cpp
+++ b/multipy/runtime/test_deploy.cpp
@@ -87,6 +87,19 @@ TEST(TorchpyTest, SimpleModel) {
   compare_torchpy_jit(path("SIMPLE", simple), path("SIMPLE_JIT", simple_jit));
 }
 
+#ifdef FBCODE_CAFFE2
+TEST(TorchpyTest, LoadTextAndBinary) {
+  torch::deploy::InterpreterManager manager(1);
+  torch::deploy::Package p = manager.loadPackage(path("SIMPLE", simple));
+
+  std::string text = p.loadText("extra_files", "text");
+  ASSERT_EQ(text, "hello");
+
+  std::string decodedBinary = p.loadBinary("extra_files", "binary");
+  ASSERT_EQ(decodedBinary, "hello");
+}
+#endif
+
 TEST(TorchpyTest, ResNet) {
   compare_torchpy_jit(
       path("RESNET", "multipy/runtime/example/generated/resnet"),


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/83882

- Adds a method to the package struct to enable reading of data saved in "extra_files" of the package
- D38378610 **[torchrec] Allow storing binary data in extra_files** - added how to save and read the extra files in python
- For warmup, I need a way to save the requests, which can only be read as binary in python and the extra_files provides a convenient way to do so

Differential Revision: D38914842

