### PR TITLE
[Setup.py] [4/n] Fix for conditional omission of cmake build in pip install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class MultipyRuntimeBuild(build_ext):
                 "Error fetching cmake version. Please ensure cmake is installed correctly."
             ) from None
         base_dir = os.path.abspath(os.path.dirname(__file__))
-        build_dir = "multipy/runtime/build3"
+        build_dir = "multipy/runtime/build"
         build_dir_abs = base_dir + "/" + build_dir
         if not os.path.exists(build_dir_abs):
             os.makedirs(build_dir_abs)
@@ -89,10 +89,11 @@ class MultipyRuntimeBuild(build_ext):
 
         print(f"-- Running multipy runtime install in dir {build_dir_abs}")
         try:
-            subprocess.check_output(
-                ["cmake", "--install", ".", "--prefix", """ "." """],
+            subprocess.run(
+                ['cmake --install . --prefix "."'],
                 cwd=build_dir_abs,
                 shell=True,
+                check=True,
             )
         except subprocess.CalledProcessError as e:
             raise RuntimeError(e.output) from None

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,12 @@ class MultipyRuntimeDevelop(develop):
 
     def initialize_options(self):
         develop.initialize_options(self)
-        self.cmakeoff=None
+        self.cmakeoff = None
 
     def finalize_options(self):
         develop.finalize_options(self)
         if self.cmakeoff is not None:
-            self.distribution.get_command_obj("build_ext").cmake_off= True
+            self.distribution.get_command_obj("build_ext").cmake_off = True
 
 
 class MultipyRuntimeBuild(build_ext):
@@ -89,8 +89,8 @@ class MultipyRuntimeBuild(build_ext):
 
         print(f"-- Running multipy runtime install in dir {build_dir_abs}")
         try:
-            subprocess.check_call(
-                ["cmake", "--install", ".", "--prefix", '"."'],
+            subprocess.check_output(
+                ["cmake", "--install", ".", "--prefix", """ "." """],
                 cwd=build_dir_abs,
                 shell=True,
             )
@@ -172,8 +172,8 @@ if __name__ == "__main__":
         },
         ext_modules=ext_modules,
         cmdclass={
-            'build_ext': MultipyRuntimeBuild,
-            'develop': MultipyRuntimeDevelop,
+            "build_ext": MultipyRuntimeBuild,
+            "develop": MultipyRuntimeDevelop,
         },
         # PyPI package information.
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,6 @@ class MultipyRuntimeBuild(build_ext):
         # TODO
         # followups: gen examples, copy .so out.
 
-        build_ext.run(self)
-
 
 ext_modules = [
     MultipyRuntimeExtension("multipy.so"),


### PR DESCRIPTION
Summary: As title.
For default pip install with cmake : `pip install -e .`
To omit cmake : `pip install -e . --install-option="--cmakeoff"`

Test Plan: Check pip installs work, with and without cmake.

Reviewers:

Subscribers:

Tasks:

Tags: