### PR TITLE
multipy/examples: added executable example

### DIFF
--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -36,6 +36,10 @@ jobs:
         run: |
           docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && multipy/runtime/build/test_deploy"
 
+      - name: Examples
+        run: |
+          docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && examples/build/hello_world_example"
+
       - name: Compat Tests
         run: |
           docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -gt 7 ]]; then pip install -r compat-requirements.txt && multipy/runtime/build/interactive_embedded_interpreter --pyscript multipy/runtime/test_compat.py; fi"

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,13 @@ ENV PATH /opt/conda/bin:$PATH
 # get the repo
 FROM dev-base as submodule-update
 WORKDIR /opt/multipy
-COPY . .
+
+# add files incrementally
+COPY .git .git
+COPY .gitmodules .gitmodules
+COPY multipy multipy
+COPY compat-requirements.txt compat-requirements.txt
+
 RUN git submodule update --init --recursive --jobs 0
 
 # Install conda/pyenv + necessary python dependencies
@@ -80,7 +86,9 @@ RUN if [[ ${PYTHON_MINOR_VERSION} -gt 7 ]]; then \
     git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
     export CFLAGS="-fPIC -g" && \
     ~/.pyenv/bin/pyenv install --force 3.7.10 && \
-    virtualenv -p ~/.pyenv/versions/3.7.10/bin/python3 ~/venvs/multipy; \
+    virtualenv -p ~/.pyenv/versions/3.7.10/bin/python3 ~/venvs/multipy && \
+    source ~/venvs/multipy/bin/activate && \
+    pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113; \
     fi
 
 # Build/Install pytorch with post-cxx11 ABI
@@ -92,19 +100,31 @@ COPY --from=submodule-update /opt/multipy /opt/multipy
 WORKDIR /opt/multipy
 
 # Build Multipy
-RUN mkdir multipy/runtime/build && \
+RUN rm -r multipy/runtime/build; mkdir multipy/runtime/build && \
     cd multipy/runtime/build && \
     if [[ ${PYTHON_MINOR_VERSION} -lt 8 ]]; then \
     source ~/venvs/multipy/bin/activate && \
-    pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113 && \
     cmake -DLEGACY_PYTHON_PRE_3_8=ON ..; \
     else \
     cmake -DLEGACY_PYTHON_PRE_3_8=OFF ..; \
     fi && \
-    cmake --build . --config Release && \
+    cmake --build . --config Release -j && \
     cmake --install . --prefix "." && \
     cd ../example && python generate_examples.py
 
+# Build examples
+COPY examples examples
+RUN cd examples && \
+    rm -r build; \
+    if [[ ${PYTHON_MINOR_VERSION} -lt 8 ]]; then \
+    source ~/venvs/multipy/bin/activate; \
+    else \
+    source /opt/conda/bin/activate; \
+    fi && \
+    cmake -S . -B build/ -DMULTIPY_PATH=".." && \
+    cmake --build build/ --config Release -j
+
 ENV PYTHONPATH=. LIBTEST_DEPLOY_LIB=multipy/runtime/build/libtest_deploy_lib.so
+
 
 RUN mkdir /opt/dist && cp -r multipy/runtime/build/dist/* /opt/dist/

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+project(multipy_tutorial)
+
+set(MULTIPY_PATH ".." CACHE PATH "The repo where multipy is built or the PYTHONPATH")
+
+# include the multipy utils to help link against
+include(${MULTIPY_PATH}/multipy/runtime/utils.cmake)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+set(TORCH_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=0")
+
+# add headers from multipy
+include_directories(${MULTIPY_PATH})
+
+# link the multipy prebuilt binary
+add_library(multipy_internal STATIC IMPORTED)
+set_target_properties(multipy_internal
+    PROPERTIES
+    IMPORTED_LOCATION
+    ${MULTIPY_PATH}/multipy/runtime/build/libtorch_deploy.a)
+caffe2_interface_library(multipy_internal multipy)
+
+# build our examples
+add_executable(hello_world_example hello_world_example.cpp)
+target_link_libraries(hello_world_example PUBLIC "-Wl,--no-as-needed -rdynamic" dl pthread util multipy c10 torch_cpu)

--- a/examples/hello_world_example.cpp
+++ b/examples/hello_world_example.cpp
@@ -1,0 +1,19 @@
+#include <multipy/runtime/deploy.h>
+#include <multipy/runtime/path_environment.h>
+#include <torch/script.h>
+#include <torch/torch.h>
+
+#include <iostream>
+#include <memory>
+
+int main(int argc, const char* argv[]) {
+  // create two interpreters
+  multipy::runtime::InterpreterManager manager(2);
+
+  // Acquire a session on one of the interpreters
+  auto I = manager.acquireOne();
+
+  // from builtins import print
+  // print("Hello world!")
+  I.global("builtins", "print")({"Hello world!"});
+}

--- a/multipy/runtime/CMakeLists.txt
+++ b/multipy/runtime/CMakeLists.txt
@@ -36,15 +36,8 @@ SET(INTERPRETER_DIR "${DEPLOY_DIR}/interpreter" PARENT_SCOPE)
 set(DEPLOY_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 get_filename_component(MULTIPY_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
 
-find_package (Python3 COMPONENTS Interpreter Development)
-set(PYTORCH_ROOT "${Python3_SITELIB}")
-
 add_subdirectory(interpreter)
 add_subdirectory(third-party/fmt)
-include_directories(BEFORE "${PYTORCH_ROOT}/torch/include")
-include_directories(BEFORE "${PYTORCH_ROOT}/torch/include/torch/csrc/api/include/")
-include_directories(BEFORE "${Python3_INCLUDE_DIRS}")
-
 
 include(${DEPLOY_DIR}/utils.cmake)
 
@@ -112,7 +105,6 @@ set(INTERPRETER_TEST_SOURCES_GPU
 # TODO: Currently tests can only be done when ABI=1 as the testing infrustructure
 # used by ASSERT_TRUE requires ABI=1 in Github actions, we should fix this!
 
-LINK_DIRECTORIES("${PYTORCH_ROOT}/torch/lib")
 add_executable(test_deploy ${INTERPRETER_TEST_SOURCES})
 # target_compile_definitions(test_deploy PUBLIC TEST_CUSTOM_LIBRARY)
 if (${LEGACY_PYTHON_PRE_3_8})

--- a/multipy/runtime/Exception.h
+++ b/multipy/runtime/Exception.h
@@ -19,7 +19,7 @@
   }
 
 #define MULTIPY_INTERNAL_ASSERT_NO_MESSAGE(condition) \
-  MULTIPY_INTERNAL_ASSERT_WITH_MESSAGE(#condition, "")
+  MULTIPY_INTERNAL_ASSERT_WITH_MESSAGE(condition, #condition)
 
 #define MULTIPY_INTERNAL_ASSERT_(x, condition, message, FUNC, ...) FUNC
 
@@ -39,7 +39,7 @@
   }
 
 #define MULTIPY_CHECK_NO_MESSAGE(condition) \
-  MULTIPY_CHECK_WITH_MESSAGE(#condition, "")
+  MULTIPY_CHECK_WITH_MESSAGE(condition, #condition)
 
 #define MULTIPY_CHECK_(x, condition, message, FUNC, ...) FUNC
 

--- a/multipy/runtime/deploy.h
+++ b/multipy/runtime/deploy.h
@@ -37,6 +37,8 @@ struct TORCH_API InterpreterSession {
   InterpreterSession(InterpreterSession&&) noexcept = default;
   // NOLINTNEXTLINE(bugprone-exception-escape)
   ~InterpreterSession();
+
+  // global imports a python object from the specified module.
   Obj global(const char* module, const char* name) {
     return impl_->global(module, name);
   }
@@ -313,3 +315,7 @@ struct TORCH_API Package {
 
 } // namespace deploy
 } // namespace torch
+
+namespace multipy {
+namespace runtime = torch::deploy;
+}

--- a/multipy/runtime/interpreter/interpreter_impl.h
+++ b/multipy/runtime/interpreter/interpreter_impl.h
@@ -10,6 +10,7 @@
 #include <ATen/core/ivalue.h>
 #include <caffe2/serialize/inline_container.h>
 
+#include <multipy/runtime/Exception.h>
 #include <multipy/runtime/interpreter/Optional.hpp>
 
 namespace torch {

--- a/multipy/runtime/mem_file.h
+++ b/multipy/runtime/mem_file.h
@@ -51,7 +51,7 @@ struct MemFile {
   [[nodiscard]] const char* data() const {
     return (const char*)mem_;
   }
-  int valid(int fd) {
+  int valid() {
     return fcntl(fd_, F_GETFD) != -1 || errno != EBADF;
   }
   ~MemFile() {

--- a/multipy/runtime/test_deploy.cpp
+++ b/multipy/runtime/test_deploy.cpp
@@ -553,6 +553,16 @@ TEST(TorchpyTest, PrintInstruction) {
   EXPECT_TRUE(result3.toTensor().equal(expected_forward));
 }
 
+TEST(MultiPyException, Assert) {
+  EXPECT_THROW(MULTIPY_INTERNAL_ASSERT(false), std::runtime_error);
+  EXPECT_THROW(MULTIPY_INTERNAL_ASSERT(false, "msg"), std::runtime_error);
+}
+
+TEST(MultiPyException, Check) {
+  EXPECT_THROW(MULTIPY_CHECK(false), std::runtime_error);
+  EXPECT_THROW(MULTIPY_CHECK(false, "msg"), std::runtime_error);
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   char tempeh[256];

--- a/multipy/runtime/utils.cmake
+++ b/multipy/runtime/utils.cmake
@@ -4,6 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+find_package (Python3 COMPONENTS Interpreter Development)
+set(PYTORCH_ROOT "${Python3_SITELIB}")
+
+include_directories(BEFORE "${PYTORCH_ROOT}/torch/include")
+include_directories(BEFORE "${PYTORCH_ROOT}/torch/include/torch/csrc/api/include/")
+include_directories(BEFORE "${Python3_INCLUDE_DIRS}")
+LINK_DIRECTORIES("${PYTORCH_ROOT}/torch/lib")
+
 macro(caffe2_interface_library SRC DST)
   add_library(${DST} INTERFACE)
   add_dependencies(${DST} ${SRC})


### PR DESCRIPTION
This adds a simple hello world example that will run in the GitHub CI. We can add the more complex package example here as well.

There's a bit of weirdness here since we need to link against the Conda environment libraries for mkl.

Test plan:

CI

```
time DOCKER_BUILDKIT=1 docker build -t multipy --progress=plain .
```