### PR TITLE
multipy: use primary python instead of newest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN rm -r multipy/runtime/build; mkdir multipy/runtime/build && \
     source ~/venvs/multipy/bin/activate && \
     cmake -DLEGACY_PYTHON_PRE_3_8=ON ..; \
     else \
-    cmake -DLEGACY_PYTHON_PRE_3_8=OFF -DPython3_EXECUTABLE="$(which python3)" ..; \
+    cmake -DLEGACY_PYTHON_PRE_3_8=OFF ..; \
     fi && \
     cmake --build . --config Release -j && \
     cmake --install . --prefix "." && \
@@ -117,7 +117,7 @@ RUN cd examples && \
     else \
     source /opt/conda/bin/activate; \
     fi && \
-    cmake -S . -B build/ -DMULTIPY_PATH=".." -DPython3_EXECUTABLE="$(which python3)" && \
+    cmake -S . -B build/ -DMULTIPY_PATH=".." && \
     cmake --build build/ --config Release -j
 
 ENV PYTHONPATH=. LIBTEST_DEPLOY_LIB=multipy/runtime/build/libtest_deploy_lib.so

--- a/multipy/runtime/utils.cmake
+++ b/multipy/runtime/utils.cmake
@@ -4,6 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# prefer the active Python version instead of the latest -- only works on cmake
+# 3.15+
+# https://cmake.org/cmake/help/latest/module/FindPython3.html#hints
+set(Python3_FIND_STRATEGY LOCATION)
+
 find_package (Python3 COMPONENTS Interpreter Development)
 set(PYTORCH_ROOT "${Python3_SITELIB}")
 


### PR DESCRIPTION
When cmake minimum version was switched in https://github.com/pytorch/multipy/commit/8c7e487e4bdd9a5490ba4eda3827ec31154fb34b it changed the default FIND_STRATEGY from LOCATION to VERSION. This explicitly switches it back so it'll prefer the active python from virtualenv/conda instead of from system even if it's newer.

https://cmake.org/cmake/help/latest/module/FindPython3.html#hints

Test plan:
```
python setup.py develop
```