### PR TITLE
Replace `TypedStorage._storage` with `TypedStorage.untyped()`

### DIFF
--- a/multipy/utils/_deploy.py
+++ b/multipy/utils/_deploy.py
@@ -37,7 +37,7 @@ def _save_storages(importer, obj):
             if isinstance(obj, STORAGE_TYPE):
                 # TODO: Once we decide to break serialization FC, we can
                 # remove this case
-                storage = obj._storage
+                storage = obj.untyped()
                 dtype = obj.dtype
             else:
                 storage = obj


### PR DESCRIPTION
As part of my PR https://github.com/pytorch/pytorch/pull/85303, I'm renaming `TypedStorage._storage` to `TypedStorage._untyped_storage` for better clarity, and since MultiPy depends on the old name, a CI job is failing on my PR. There is a public function `TypedStorage.untyped()` which is probably better to use in this case, and doing so will fix the CI failure for me

cc @ezyang