### PR TITLE
[Buildfiles] Remove python major version option from buildfiles.

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -14,15 +14,14 @@ jobs:
   unittest:
     strategy:
       matrix:
-        python-major-version: [3]
-        python-minor-version: [7,8,9,10]
+        python3-minor-version: [7,8,9,10]
         platform: [ubuntu-18.04]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set Python Version
         run: |
-          echo "python-version=${{ matrix.python-major-version }}.${{ matrix.python-minor-version }}" >> $GITHUB_ENV
+          echo "python-version=3.${{ matrix.python3-minor-version }}" >> $GITHUB_ENV
       - name: Setup Python ${{ env.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -58,7 +57,7 @@ jobs:
           py_version_dict[8]='3.8.13'
           py_version_dict[9]='3.9.13'
           py_version_dict[10]='3.10.6'
-          py_install_version=${py_version_dict[${{ matrix.python-minor-version }}]}
+          py_install_version=${py_version_dict[${{ matrix.python3-minor-version }}]}
           ~/.pyenv/bin/pyenv install --force ${py_install_version}
           virtualenv -p ~/.pyenv/versions/${py_install_version}/bin/python3 ~/venvs/multipy
 
@@ -88,7 +87,7 @@ jobs:
       - name: Install dependencies with conda for 3.8+
         run: |
           set -eux
-          if [[ ${{ matrix.python-minor-version }} -gt 7 ]]; then \
+          if [[ ${{ matrix.python3-minor-version }} -gt 7 ]]; then \
           curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
           chmod +x ~/miniconda.sh && \
           ~/miniconda.sh -b -p /opt/conda && \
@@ -102,7 +101,7 @@ jobs:
       - name: Run pip install with conda for 3.8+
         run: |
           set -eux
-          if [[ ${{ matrix.python-minor-version }} -gt 7 ]]; then
+          if [[ ${{ matrix.python3-minor-version }} -gt 7 ]]; then
             source /opt/conda/bin/activate
             pip install -e .
           fi

--- a/.github/workflows/runtime_nightly.yaml
+++ b/.github/workflows/runtime_nightly.yaml
@@ -9,8 +9,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        python-major-version: [3]
-        python-minor-version: [7,8,9,10]
+        python3-minor-version: [7,8,9,10]
         platform: [ubuntu-18.04]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
@@ -28,19 +27,19 @@ jobs:
       - name: Build
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t multipy --progress=plain --build-arg PYTHON_MAJOR_VERSION=${{ matrix.python-major-version }} --build-arg PYTHON_MINOR_VERSION=${{ matrix.python-minor-version }} .
+        run: docker build -t multipy --progress=plain --build-arg --build-arg PYTHON_3_MINOR_VERSION=${{ matrix.python3-minor-version }} .
 
       - name: Test
         run: |
-          docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && multipy/runtime/build/test_deploy"
+          docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && multipy/runtime/build/test_deploy"
 
       - name: Compat Tests
         run: |
-          docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -gt 7 ]]; then pip install -r compat-requirements.txt && multipy/runtime/build/interactive_embedded_interpreter --pyscript multipy/runtime/test_compat.py; fi"
+          docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -gt 7 ]]; then pip install -r compat-requirements.txt && multipy/runtime/build/interactive_embedded_interpreter --pyscript multipy/runtime/test_compat.py; fi"
 
       - name: Set Python Version
         run: |
-          echo "python-version=${{ matrix.python-major-version }}.${{ matrix.python-minor-version }}" >> $GITHUB_ENV
+          echo "python-version=3.${{ matrix.python3-minor-version }}" >> $GITHUB_ENV
 
       - name: Create Tarball
         run: |

--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -11,8 +11,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        python-major-version: [3]
-        python-minor-version: [7,8,9,10]
+        python3-minor-version: [7,8,9,10]
         platform: [linux.4xlarge.nvidia.gpu]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
@@ -42,20 +41,20 @@ jobs:
       - name: Build
         env:
           DOCKER_BUILDKIT: 1
-        run: nvidia-docker build -t multipy --progress=plain --build-arg PYTHON_MAJOR_VERSION=${{ matrix.python-major-version }} --build-arg PYTHON_MINOR_VERSION=${{ matrix.python-minor-version }} --build-arg BUILD_CUDA_TESTS=1 .
+        run: nvidia-docker build -t multipy --progress=plain --build-arg --build-arg PYTHON_3_MINOR_VERSION=${{ matrix.python3-minor-version }} --build-arg BUILD_CUDA_TESTS=1 .
 
       - name: Test
         run: |
-          docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && multipy/runtime/build/test_deploy"
-          nvidia-docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && multipy/runtime/build/test_deploy_gpu"
+          docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && multipy/runtime/build/test_deploy"
+          nvidia-docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && multipy/runtime/build/test_deploy_gpu"
 
 
       - name: Examples
         run: |
-          docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && examples/build/hello_world_example"
-          docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && python3 examples/quickstart/gen_package.py && ./examples/build/quickstart my_package.pt"
-          docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && ./examples/build/movable_example"
+          docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && examples/build/hello_world_example"
+          docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && python3 examples/quickstart/gen_package.py && ./examples/build/quickstart my_package.pt"
+          docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && ./examples/build/movable_example"
 
       - name: Compat Tests
         run: |
-          docker run --rm multipy bash -c "if [[ ${{ matrix.python-minor-version }} -gt 7 ]]; then pip install -r compat-requirements.txt && multipy/runtime/build/interactive_embedded_interpreter --pyscript multipy/runtime/test_compat.py; fi"
+          docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -gt 7 ]]; then pip install -r compat-requirements.txt && multipy/runtime/build/interactive_embedded_interpreter --pyscript multipy/runtime/test_compat.py; fi"

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,12 +67,11 @@ RUN git submodule update --init --recursive --jobs 0
 
 # Install conda/pyenv + necessary python dependencies
 FROM dev-base as conda-pyenv
-ARG PYTHON_MAJOR_VERSION=3
-ARG PYTHON_MINOR_VERSION=8
+ARG PYTHON_3_MINOR_VERSION=8
 ARG BUILD_CUDA_TESTS=0
-ENV PYTHON_MINOR_VERSION=${PYTHON_MINOR_VERSION}
-ENV PYTHON_VERSION=${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}
-RUN if [[ ${PYTHON_MINOR_VERSION} -gt 7 ]]; then \
+ENV PYTHON_3_MINOR_VERSION=${PYTHON_3_MINOR_VERSION}
+ENV PYTHON_VERSION=3.${PYTHON_3_MINOR_VERSION}
+RUN if [[ ${PYTHON_3_MINOR_VERSION} -gt 7 ]]; then \
     curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -p /opt/conda && \
@@ -99,7 +98,7 @@ WORKDIR /opt/multipy
 
 # Build Multipy
 RUN ls && pwd && rm -rf multipy/runtime/build && \
-    if [[ ${PYTHON_MINOR_VERSION} -lt 8 ]]; then \
+    if [[ ${PYTHON_3_MINOR_VERSION} -lt 8 ]]; then \
     source ~/venvs/multipy/bin/activate; \
     fi && \
     if [[ ${BUILD_CUDA_TESTS} -eq 1 ]]; then \
@@ -113,7 +112,7 @@ RUN ls && pwd && rm -rf multipy/runtime/build && \
 COPY examples examples
 RUN cd examples && \
     rm -r build; \
-    if [[ ${PYTHON_MINOR_VERSION} -lt 8 ]]; then \
+    if [[ ${PYTHON_3_MINOR_VERSION} -lt 8 ]]; then \
     source ~/venvs/multipy/bin/activate; \
     else \
     source /opt/conda/bin/activate; \


### PR DESCRIPTION
Summary: As title. We support python 3.7+ only.

Test Plan: Unit tests should work.

Reviewers:

Subscribers:

Tasks:

Tags: