### PR TITLE
multipy/setup.py: make whl/sdist builds installable w/ C++ build

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  unittest:
+  installtest:
     strategy:
       matrix:
         python-major-version: [3]
@@ -77,13 +77,36 @@ jobs:
           pip install -e . --install-option="--cmakeoff"
           deactivate
 
-      - name: Run pip install within virtualenv
+      - name: Run pip editable install within virtualenv
         run: |
           set -eux
           source ~/venvs/multipy/bin/activate
           rm -rf multipy/runtime/build*
           pip install -e .
           deactivate
+
+      - name: Run setup.py install within virtualenv
+        run: |
+          set -eux
+          source ~/venvs/multipy/bin/activate
+          python setup.py install
+          test -e ~/venvs/multipy/lib/python3.*/site-packages/multipy/runtime/build/libtorch_deploy.a
+
+      - name: Install sdist
+        run: |
+          set -eux
+          source ~/venvs/multipy/bin/activate
+          python setup.py sdist
+          pip install dist/*.tar.gz --force-reinstall
+          test -e ~/venvs/multipy/lib/python3.*/site-packages/multipy/runtime/build/libtorch_deploy.a
+
+      - name: Install bdist_wheel
+        run: |
+          set -eux
+          source ~/venvs/multipy/bin/activate
+          python setup.py bdist_wheel
+          pip install dist/*.whl --force-reinstall
+          test -e ~/venvs/multipy/lib/python3.*/site-packages/multipy/runtime/build/libtorch_deploy.a
 
       - name: Install dependencies with conda for 3.8+
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples/**/*.pt
 **/.DS_Store/**
 docs/source/api/
 docs/src/
+dist/

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import os.path
 import re
+import shutil
 import subprocess
 import sys
 from datetime import date
+from distutils.command.clean import clean
 
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
@@ -80,6 +83,7 @@ class MultipyRuntimeBuild(MultipyRuntimeCmake, build_ext):
             os.makedirs(build_dir_abs)
         legacy_python_cmake_flag = "OFF" if sys.version_info.minor > 7 else "ON"
 
+        print(f"build_lib {self.build_lib}")
         print(f"-- Running multipy runtime makefile in dir {build_dir_abs}")
         try:
             subprocess.run(
@@ -120,6 +124,33 @@ class MultipyRuntimeBuild(MultipyRuntimeCmake, build_ext):
             )
         except subprocess.CalledProcessError as e:
             raise RuntimeError(e.output.decode("utf-8")) from None
+
+        print("-- Copying build outputs")
+        paths = [
+            "multipy/runtime/build/libtorch_deploy.a",
+            "multipy/runtime/build/interactive_embedded_interpreter",
+            "multipy/runtime/build/test_deploy",
+        ]
+        for path in paths:
+            target = os.path.join(self.build_lib, path)
+            target_dir = os.path.dirname(target)
+            if not os.path.exists(target_dir):
+                print(f"creating dir {target_dir}")
+                os.makedirs(target_dir)
+            print(f"copying {path} -> {target}")
+            shutil.copy2(path, target)
+
+
+class MultipyRuntimeClean(clean):
+    def run(self):
+        paths = [
+            "multipy/runtime/build",
+        ]
+        for path in paths:
+            if os.path.exists(path):
+                print(f"removing: {path}")
+                shutil.rmtree(path)
+        super().run()
 
 
 class MultipyRuntimeInstall(MultipyRuntimeCmake, install):
@@ -227,7 +258,29 @@ if __name__ == "__main__":
             "build_ext": MultipyRuntimeBuild,
             "develop": MultipyRuntimeDevelop,
             "install": MultipyRuntimeInstall,
+            "clean": MultipyRuntimeClean,
         },
+        package_data={
+            "multipy": [
+                "runtime/*",
+                "runtime/example/*",
+                "runtime/example/fx/*",
+                "runtime/interpreter/*",
+                "runtime/third-party/fmt/*",
+                "runtime/third-party/fmt/include/fmt/*",
+                "runtime/third-party/fmt/src/*",
+                "runtime/third-party/fmt/support/cmake/*",
+            ]
+        },
+        data_files=[
+            (
+                "",
+                [
+                    "requirements.txt",
+                    "dev-requirements.txt",
+                ],
+            )
+        ],
         # PyPI package information.
         classifiers=[
             "Development Status :: 4 - Beta",


### PR DESCRIPTION
This makes the whl/sdist builds include the C++ artifacts. This will enable us to upload the released version to pypi.

Test plan:

```
python setup.py clean sdist bdist_wheel
pip install dist/multipy-0.1.0.dev0-cp38-cp38-linux_x86_64.whl
pip install dist/multipy-0.1.0.dev0.tar.gz

# check presence
~/venvs/multipy3.8.6/lib/python3.8/site-packages/multipy/runtime/build/interactive_embedded_interpreter
```
