### PR TITLE
Remove references to old location of torchdynamo

### DIFF
--- a/multipy/runtime/test_compat.py
+++ b/multipy/runtime/test_compat.py
@@ -24,7 +24,7 @@ class TestCompat(unittest.TestCase):
 
     @unittest.skip("torch.Library is not supported")
     def test_torchdynamo_eager(self):
-        import torchdynamo
+        import torch._dynamo as torchdynamo
 
         @torchdynamo.optimize("eager")
         def fn(x, y):
@@ -36,7 +36,7 @@ class TestCompat(unittest.TestCase):
 
     @unittest.skip("torch.Library is not supported")
     def test_torchdynamo_ofi(self):
-        import torchdynamo
+        import torch._dynamo as torchdynamo
 
         torchdynamo.reset()
 


### PR DESCRIPTION
Summary:
//pytorch/torchdynamo is now part of //caffe2:torch (but also requires //caffe2/functorch).
Modules torchdynamo and torchinductor become torch._dynamo and torch._inductor

Differential Revision: D40809788

