### PR TITLE
remove abicxx flag in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ class MultipyRuntimeCmake(object):
     user_options = [
         ("cmakeoff", None, None),
         ("cudatests", None, None),
-        ("abicxx", None, None),
     ]
 
 
@@ -44,9 +43,6 @@ class MultipyRuntimeDevelop(MultipyRuntimeCmake, develop):
     def initialize_options(self):
         develop.initialize_options(self)
         self.cmakeoff = None
-
-        # TODO(tristanr): remove once unused
-        self.abicxx = None
 
         self.cudatests = None
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #245

After https://github.com/pytorch/pytorch/pull/88107 is merged, we can remove the `abicxx` flag from `setup.py` as its no longer needed.

Differential Revision: [D40873178](https://our.internmc.facebook.com/intern/diff/D40873178)