### PR TITLE
Add python3 to doc_push.sh

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -38,7 +38,7 @@ jobs:
   docpush:
     runs-on: ubuntu-18.04
     needs: docbuild
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -38,7 +38,7 @@ jobs:
   docpush:
     runs-on: ubuntu-18.04
     needs: docbuild
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -59,11 +59,8 @@ jobs:
           pip install -r docs/requirements.txt
       - name: Build
         run: |
-          # Not sure why this is on python 2, but if we are only
-          # printing out variables, it should be fine. Let's change
-          # it if we are doing something more complicated.
           set -ex
-          sudo bash docs/doc_push.sh --dry-run --python2
+          sudo bash docs/doc_push.sh --dry-run
       - name: Push
         run: |
           set -ex

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -59,8 +59,11 @@ jobs:
           pip install -r docs/requirements.txt
       - name: Build
         run: |
+          # Not sure why this is on python 2, but if we are only
+          # printing out variables, it should be fine. Let's change
+          # it if we are doing something more complicated.
           set -ex
-          sudo bash docs/doc_push.sh --dry-run
+          sudo bash docs/doc_push.sh --dry-run --python2
       - name: Push
         run: |
           set -ex

--- a/docs/doc_push.sh
+++ b/docs/doc_push.sh
@@ -36,7 +36,8 @@ for arg in "$@"; do
     shift
     case "$arg" in
         "--dry-run") dry_run=1 ;;
-        "--help") echo "Usage $0 [--dry-run]"; exit 0 ;;
+        "--python2") python2=1 ;;
+        "--help") echo "Usage $0 [--dry-run, --python2]"; exit 0 ;;
     esac
 done
 
@@ -57,10 +58,12 @@ fi
 echo "Installing multipy from $repo_root..."
 cd "$repo_root" || exit
 
-# Not sure why this is on python 2, but if we are only
-# printing out variables, it should be fine. Let's change
-# it if we are doing something more complicated.
- multipy_ver=$(python -c "from multipy.version import __version__; print __version__")
+# Python 2 version needed as CI runs this script using python 2 for some reason
+if [ $python2 -eq 1 ]; then
+    multipy_ver=$(python -c "from multipy.version import __version__; print __version__")
+else
+    multipy_ver=$(python -c "from multipy.version import __version__; print(__version__)")
+fi
 
 echo "Building multipy-$multipy_ver docs..."
 docs_dir=$repo_root/docs

--- a/docs/doc_push.sh
+++ b/docs/doc_push.sh
@@ -58,12 +58,7 @@ fi
 echo "Installing multipy from $repo_root..."
 cd "$repo_root" || exit
 
-# Python 2 version needed as CI runs this script using python 2 for some reason
-if [ $python2 -eq 1 ]; then
-    multipy_ver=$(python -c "from multipy.version import __version__; print __version__")
-else
-    multipy_ver=$(python -c "from multipy.version import __version__; print(__version__)")
-fi
+multipy_ver=$(python3 -c "from multipy.version import __version__; print(__version__)")
 
 echo "Building multipy-$multipy_ver docs..."
 docs_dir=$repo_root/docs

--- a/docs/doc_push.sh
+++ b/docs/doc_push.sh
@@ -36,8 +36,7 @@ for arg in "$@"; do
     shift
     case "$arg" in
         "--dry-run") dry_run=1 ;;
-        "--python2") python2=1 ;;
-        "--help") echo "Usage $0 [--dry-run, --python2]"; exit 0 ;;
+        "--help") echo "Usage $0 [--dry-run]"; exit 0 ;;
     esac
 done
 
@@ -58,6 +57,8 @@ fi
 echo "Installing multipy from $repo_root..."
 cd "$repo_root" || exit
 
+# For some reason the CI uses python 3.6 for the script, so we can't build multipy.
+# Fortunately, we just need the version.
 multipy_ver=$(python3 -c "from multipy.version import __version__; print(__version__)")
 
 echo "Building multipy-$multipy_ver docs..."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #247

Due to an unknown bug in our CI, `doc_push.sh` is run using python2, however, this script needs to be run manually for releases where using python2 is not intuitive. This PR explicitly uses python 3 to make manual runs more intuitive.

Differential Revision: [D40896675](https://our.internmc.facebook.com/intern/diff/D40896675)