### PR TITLE
use multiple interpreters for unit tests

### DIFF
--- a/multipy/runtime/test_deploy.cpp
+++ b/multipy/runtime/test_deploy.cpp
@@ -22,7 +22,7 @@
 void compare_torchpy_jit(const char* model_filename, const char* jit_filename) {
   // Test
 
-  torch::deploy::InterpreterManager m(1);
+  torch::deploy::InterpreterManager m(2);
   torch::deploy::Package p = m.loadPackage(model_filename);
   auto model = p.loadPickle("model", "model.pkl");
   at::IValue eg;

--- a/multipy/runtime/test_deploy_gpu.cpp
+++ b/multipy/runtime/test_deploy_gpu.cpp
@@ -35,7 +35,7 @@ TEST(TorchDeployGPUTest, SimpleModel) {
   const char* jit_filename = path("SIMPLE_JIT", simple_jit);
 
   // Test
-  torch::deploy::InterpreterManager m(1);
+  torch::deploy::InterpreterManager m(2);
   torch::deploy::Package p = m.loadPackage(model_filename);
   auto model = p.loadPickle("model", "model.pkl");
   {
@@ -64,7 +64,7 @@ TEST(TorchDeployGPUTest, SimpleModel) {
 TEST(TorchDeployGPUTest, UsesDistributed) {
   const auto model_filename = path(
       "USES_DISTRIBUTED", "multipy/runtime/example/generated/uses_distributed");
-  torch::deploy::InterpreterManager m(1);
+  torch::deploy::InterpreterManager m(2);
   torch::deploy::Package p = m.loadPackage(model_filename);
   {
     auto I = p.acquireSession();
@@ -81,7 +81,7 @@ TEST(TorchDeployGPUTest, UsesCuda) {
 
   const auto model_filename =
       path("USES_CUDA", "multipy/runtime/example/generated/uses_cuda");
-  torch::deploy::InterpreterManager m(1);
+  torch::deploy::InterpreterManager m(2);
   torch::deploy::Package p = m.loadPackage(model_filename);
   {
     auto I = p.acquireSession();
@@ -96,7 +96,7 @@ TEST(TorchDeployGPUTest, TensorRT) {
   }
   auto packagePath = path(
       "MAKE_TRT_MODULE", "multipy/runtime/example/generated/make_trt_module");
-  torch::deploy::InterpreterManager m(1);
+  torch::deploy::InterpreterManager m(2);
   torch::deploy::Package p = m.loadPackage(packagePath);
   auto makeModel = p.loadPickle("make_trt_module", "model.pkl");
   {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #248

While playing around with `benchmark.cpp` I discovered it was reasonable to cheat only one interpreter working if there is logic regarding how many interpreters can touch a resource such as what [pytorch has](https://github.com/pytorch/pytorch/blob/1f34067e9d83aa11f2f4d0ecd08cb0e0ed94dbd0/c10/core/TensorImpl.h#L1993). Using multiple interpreters during unit tests makes them more robust for use cases like this, so we can catch errors earlier.

Differential Revision: [D40902488](https://our.internmc.facebook.com/intern/diff/D40902488)