### PR TITLE
[Cleanup] Replace * with minor version.

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -89,7 +89,7 @@ jobs:
           set -eux
           source ~/venvs/multipy/bin/activate
           python setup.py install
-          test -e ~/venvs/multipy/lib/python3.*/site-packages/multipy/runtime/build/libtorch_deploy.a
+          test -e ~/venvs/multipy/lib/python3.${{ matrix.python3-minor-version }}/site-packages/multipy/runtime/build/libtorch_deploy.a
 
       - name: Install sdist
         run: |
@@ -97,7 +97,7 @@ jobs:
           source ~/venvs/multipy/bin/activate
           python setup.py sdist
           pip install dist/*.tar.gz --force-reinstall
-          test -e ~/venvs/multipy/lib/python3.*/site-packages/multipy/runtime/build/libtorch_deploy.a
+          test -e ~/venvs/multipy/lib/python3.${{ matrix.python3-minor-version }}/site-packages/multipy/runtime/build/libtorch_deploy.a
 
       - name: Install bdist_wheel
         run: |
@@ -105,7 +105,7 @@ jobs:
           source ~/venvs/multipy/bin/activate
           python setup.py bdist_wheel
           pip install dist/*.whl --force-reinstall
-          test -e ~/venvs/multipy/lib/python3.*/site-packages/multipy/runtime/build/libtorch_deploy.a
+          test -e ~/venvs/multipy/lib/python3.${{ matrix.python3-minor-version }}/site-packages/multipy/runtime/build/libtorch_deploy.a
 
       - name: Install dependencies with conda for 3.8+
         run: |


### PR DESCRIPTION
Summary: The * is not always resolving correctly (e.g. https://github.com/pytorch/multipy/actions/runs/3388980279/jobs/5631569578). Better to explicitly use the minor version number.

Test Plan: Unit tests should pass.

Reviewers:

Subscribers:

Tasks:

Tags: