### PR TITLE
Have docs push action exit gracefully when there are no new docs

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -66,4 +66,4 @@ jobs:
           set -ex
           cd /tmp/multipy_docs_tmp/multipy_gh_pages
           sudo git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git push
+          git diff --exit-code gh-pages origin/gh-pages || git push

--- a/docs/doc_push.sh
+++ b/docs/doc_push.sh
@@ -89,6 +89,7 @@ for redirect in "${redirects[@]}"; do
   ln -s "$multipy_ver" "$redirect"
 done
 
+git diff --exit-code && exit
 git add .
 git commit --quiet -m "[doc_push][$release_tag] built from $commit_id ($branch). Redirects: ${redirects[*]} -> $multipy_ver."
 


### PR DESCRIPTION
Closes #256.

Check that CI passed as follows:
1. [no new docs](https://github.com/miles170/multipy/actions/runs/3391139795)
2. [got new docs](https://github.com/miles170/multipy/actions/runs/3391179107)