### PR TITLE
only rebuild docs if needed

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -66,4 +66,8 @@ jobs:
           set -ex
           cd /tmp/multipy_docs_tmp/multipy_gh_pages
           sudo git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          if git diff --exit-code gh-pages origin/gh-pages; then
+            echo "Docs are unchanged, skipping push"
+            exit
+          fi
           git push

--- a/docs/doc_push.sh
+++ b/docs/doc_push.sh
@@ -90,7 +90,7 @@ for redirect in "${redirects[@]}"; do
 done
 
 git add .
-git commit --quiet -m "[doc_push][$release_tag] built from $commit_id ($branch). Redirects: ${redirects[*]} -> $multipy_ver."
+git commit --allow-empty --quiet -m "[doc_push][$release_tag] built from $commit_id ($branch). Redirects: ${redirects[*]} -> $multipy_ver."
 
 if [ $dry_run -eq 1 ]; then
     echo "*** --dry-run mode, skipping push to gh-pages branch. To publish run: cd ${gh_pages_dir} && git push"


### PR DESCRIPTION
Closes #256

The github docpush action was failing every time that the documentation was not changed.
Fix this by ignoring the error in `git commit` and skipping the push if the commit is empty.

[Docs aren't changed](https://github.com/pytorch/multipy/actions/runs/3412994558/jobs/5679209085)
[Docs are changed](https://github.com/pytorch/multipy/actions/runs/3413028644/jobs/5679288525)