### PR TITLE
Address GetPythonFramesFunction() and multipy incompatibility.

### DIFF
--- a/multipy/runtime/deploy.h
+++ b/multipy/runtime/deploy.h
@@ -5,6 +5,11 @@
 // LICENSE file in the root directory of this source tree.
 
 #pragma once
+
+#ifndef USE_MULTIPY
+#define USE_MULTIPY
+#endif
+
 #include <c10/util/irange.h>
 #include <multipy/runtime/embedded_file.h>
 #include <multipy/runtime/interpreter/interpreter_impl.h>


### PR DESCRIPTION
Summary: https://github.com/pytorch/pytorch/pull/89122 introduces internal compatibility issues with torchdeploy. However, GetPythonFramesFunction() never worked with torchdeploy, so this PR simply reverts to the original behavior of skipping the function if torchdeploy is used as a forward fix.

Differential Revision: D41414263

