### PR TITLE
Include torchgen in zipped modules

### DIFF
--- a/multipy/runtime/environment.h
+++ b/multipy/runtime/environment.h
@@ -51,6 +51,9 @@ class Environment {
     extraPythonPaths_.push_back(getZippedArchive(
         ".multipy_python_modules",
         std::string(pythonAppDir) + "/multipy_python_modules.zip"));
+    extraPythonPaths_.push_back(getZippedArchive(
+        ".torchgen_python_modules",
+        std::string(pythonAppDir) + "/torchgen_python_modules.zip"));
 
 #endif
     extraPythonLibrariesDir_ = pythonAppDir;

--- a/multipy/runtime/interpreter/interpreter_impl.cpp
+++ b/multipy/runtime/interpreter/interpreter_impl.cpp
@@ -161,6 +161,10 @@ class RegisterModuleImporter(importlib.abc.InspectLoader):
 # print(f"modules: {sys.modules}", file=sys.stderr)
 
 import torch # has to be done serially otherwise things will segfault
+
+# test other zipped modules
+import torchgen
+
 import multipy.utils
 try:
   import torch.version # for some reason torch doesn't import this and cuda fails?

--- a/multipy/runtime/interpreter/interpreter_impl.cpp
+++ b/multipy/runtime/interpreter/interpreter_impl.cpp
@@ -151,14 +151,14 @@ class RegisterModuleImporter(importlib.abc.InspectLoader):
             return importlib.util.spec_from_loader(fullname, self)
         return None
 
-# print("exec_prefix:", sys.base_exec_prefix)
-# print("_base_executable:", sys._base_executable)
-# print("base_prefix:", sys.base_prefix)
-# print("exec_prefix:", sys.exec_prefix)
-# print("executable:", sys.executable)
-# print("path:", sys.path)
-# print("prefix:", sys.prefix)
-# print("modules:", sys.modules)
+# print(f"exec_prefix: {sys.base_exec_prefix}", file=sys.stderr)
+# print(f"_base_executable: {sys._base_executable}", file=sys.stderr)
+# print(f"base_prefix: {sys.base_prefix}", file=sys.stderr)
+# print(f"exec_prefix: {sys.exec_prefix}", file=sys.stderr)
+# print(f"executable: {sys.executable}", file=sys.stderr)
+# print(f"path: {sys.path}", file=sys.stderr)
+# print(f"prefix: {sys.prefix}", file=sys.stderr)
+# print(f"modules: {sys.modules}", file=sys.stderr)
 
 import torch # has to be done serially otherwise things will segfault
 import multipy.utils


### PR DESCRIPTION
Summary:
`torchgen` is added as a zipped module so we can support importing it. Now we can unrevert this diff: D41656946.

importing torchgen was also added in interpreter python start script so that tests will break if this is no longer possible

Differential Revision: D41695743

