### PR TITLE
avoid fork in platform.system()

### DIFF
--- a/multipy/runtime/interpreter/interpreter_impl.cpp
+++ b/multipy/runtime/interpreter/interpreter_impl.cpp
@@ -121,6 +121,11 @@ std::vector<::torch::jit::StackEntry> noPythonCallstack() {
 
 const char* start = R"PYTHON(
 import _ssl # must come before _hashlib otherwise ssl's locks will be set to a Python that might no longer exist...
+
+# Avoid fork in platform.system()
+import platform
+platform.system = lambda: "Linux"
+
 import sys
 import importlib.abc
 import linecache


### PR DESCRIPTION
Summary: Fork is considered harmful in a cpp service, we should try our best to avoid calling into fork in multipy

Differential Revision: D41868318

