### PR TITLE
multipy: beginnings of pybind support

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -17,6 +17,8 @@ jobs:
           architecture: x64
       - name: Checkout MultiPy
         uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Install Dependencies
         run: |
           set -eux

--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Checkout MultiPy
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Install runtime build dependencies
         run: |

--- a/.github/workflows/runtime_tests.yaml
+++ b/.github/workflows/runtime_tests.yaml
@@ -32,11 +32,14 @@ jobs:
           DOCKER_BUILDKIT: 1
         run: nvidia-docker build -t multipy --progress=plain --build-arg PYTHON_3_MINOR_VERSION=${{ matrix.python3-minor-version }} --build-arg BUILD_CUDA_TESTS=1 .
 
-      - name: Test
+      - name: C++ Tests
         run: |
           docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && multipy/runtime/build/test_deploy"
           nvidia-docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && multipy/runtime/build/test_deploy_gpu"
 
+      - name: Pybind Tests
+        run: |
+          docker run --rm multipy bash -c "if [[ ${{ matrix.python3-minor-version }} -lt 8 ]]; then source ~/venvs/multipy/bin/activate; fi && python multipy/runtime/test_pybind.py"
 
       - name: Examples
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "multipy/runtime/third-party/pybind11"]
 	path = multipy/runtime/third-party/pybind11
 	url = https://github.com/pybind/pybind11.git
-[submodule "multipy/runtime/third-party/pytorch"]
-	path = multipy/runtime/third-party/pytorch
-	url = https://github.com/pytorch/pytorch.git

--- a/multipy/runtime/CMakeLists.txt
+++ b/multipy/runtime/CMakeLists.txt
@@ -21,7 +21,7 @@ message(STATUS "CMAKE_BUILD_TYPE - ${CMAKE_BUILD_TYPE}" )
 set(DEPLOY_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 get_filename_component(MULTIPY_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fabi-version=11 -fno-lto")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fabi-version=11 -fno-lto -fPIC")
 include(${DEPLOY_DIR}/utils.cmake)
 
 add_subdirectory(interpreter)
@@ -171,3 +171,10 @@ install (
 
 install(TARGETS torch_deploy DESTINATION dist/multipy/runtime/lib)
 install(TARGETS torch_deployinterpreter DESTINATION dist/multipy/runtime/lib)
+
+add_subdirectory(third-party/pybind11)
+pybind11_add_module(multipy_pybind pybind_init.cpp)
+target_include_directories(multipy_pybind PRIVATE ${CMAKE_SOURCE_DIR}/../..)
+target_link_libraries(multipy_pybind
+  PUBLIC "-Wl,--no-as-needed -rdynamic" dl torch_deploy_interface c10 torch_cpu torch_python
+)

--- a/multipy/runtime/__init__.py
+++ b/multipy/runtime/__init__.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This contains a pybinded interface to MultiPy's subinterpreters. This enables
+running child interpreters from an existing python process without having any
+shared GIL.
+
+WARNING: This is currently a prototype and is subject to change at any point.
+
+Current limitations:
+* Obj must be destroyed/GCed before the InterpreterSession is destroyed. If left
+    up to GC in most cases it will crash the program.
+* No pickle interface for smartly transferring models between interpreters
+
+See test_pybind.py for examples on how to use.
+"""
+
+import ctypes
+import os
+import os.path
+
+import torch
+
+# We need to load libtorch into the global symbol space so the subinterpreters
+# can use it.
+torch_dir = os.path.dirname(torch.__file__)
+libtorch_path = os.path.join(torch_dir, "lib", "libtorch.so")
+ctypes.CDLL(libtorch_path, mode=ctypes.RTLD_GLOBAL)
+
+from multipy.runtime.build.multipy_pybind import InterpreterManager  # noqa: F401

--- a/multipy/runtime/elf_file.cpp
+++ b/multipy/runtime/elf_file.cpp
@@ -74,9 +74,7 @@ inline bool exists(const char* name) {
 
 multipy::optional<Section> searchForSection(const char* name) {
   {
-    std::string execPath;
-    std::ifstream("/proc/self/cmdline") >> execPath;
-    ElfFile elfFile(execPath.c_str());
+    ElfFile elfFile("/proc/self/exe");
     auto section = elfFile.findSection(name);
     if (section) {
       return section;

--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -60,6 +60,7 @@ set(INTERPRETER_LIB_SOURCES
   ${INTERPRETER_DIR}/builtin_registry.cpp
   ${INTERPRETER_DIR}/import_find_sharedfuncptr.cpp
   ${INTERPRETER_DIR}/plugin_registry.cpp
+  ${INTERPRETER_DIR}/../loader.cpp
   ${LINKER_SCRIPT}
 )
 add_library(torch_deployinterpreter SHARED ${INTERPRETER_LIB_SOURCES} ${LINKER_SCRIPT})
@@ -80,5 +81,4 @@ target_include_directories(torch_deployinterpreter BEFORE PUBLIC ${Python3_INCLU
 
 target_link_libraries(torch_deployinterpreter PRIVATE fmt::fmt-header-only)
 target_link_libraries(torch_deployinterpreter PRIVATE torch_python)
-target_link_libraries(torch_deployinterpreter PRIVATE gtest)
 target_link_libraries(torch_deployinterpreter PRIVATE multipy_torch)

--- a/multipy/runtime/loader.cpp
+++ b/multipy/runtime/loader.cpp
@@ -1024,15 +1024,16 @@ struct __attribute__((visibility("hidden"))) CustomLibraryImpl
       }
     }
 
+    // search in this binary first -- equivalent to RTLD_DEEPBIND behavior
+    auto r = sym(sym_name, version);
+    if (r) {
+      return r;
+    }
     for (const auto& sys_lib : symbol_search_path_) {
       auto r = sys_lib->sym(sym_name, version);
       if (r) {
         return r;
       }
-    }
-    auto r = sym(sym_name, version);
-    if (r) {
-      return r;
     }
     if (ELF64_ST_BIND(sym_st.st_info) != STB_WEAK) {
       if (!version) {

--- a/multipy/runtime/pybind_init.cpp
+++ b/multipy/runtime/pybind_init.cpp
@@ -1,0 +1,71 @@
+#include <multipy/runtime/deploy.h>
+#include <pybind11/pybind11.h>
+#include <torch/csrc/jit/python/pybind_utils.h>
+#include <torch/csrc/lazy/core/debug_util.h>
+
+namespace py = pybind11;
+
+using namespace torch::deploy;
+
+namespace {
+at::IValue detachIValue(at::IValue&& iv) {
+  if (iv.isTensor()) {
+    // detach tensors to avoid cross interpreter autograd state
+    return std::move(iv).toTensor().detach();
+  }
+  return iv;
+}
+at::IValue toIValue(const py::handle& obj) {
+  return detachIValue(torch::jit::toTypeInferredIValue(obj));
+}
+} // namespace
+
+PYBIND11_MODULE(multipy_pybind, m) {
+  m.doc() = "multipy python bindings";
+
+  py::class_<InterpreterManager>(m, "InterpreterManager")
+      .def(py::init<size_t>())
+      .def("acquire_one", &InterpreterManager::acquireOne)
+      .def(
+          "__len__",
+          [](InterpreterManager& self) -> int {
+            return self.allInstances().size();
+          })
+      .def(
+          "__getitem__",
+          [](InterpreterManager& self, int i) -> InterpreterSession {
+            return self.allInstances().at(i).acquireSession();
+          });
+
+  py::class_<Interpreter>(m, "Interpreter")
+      .def("acquire_session", &Interpreter::acquireSession);
+
+  py::class_<InterpreterSession>(m, "InterpreterSession")
+      .def("global_", &InterpreterSession::global);
+
+  py::class_<Obj>(m, "Obj")
+      .def(
+          "__call__",
+          [](Obj& self, py::args args, const py::kwargs& kwargs) -> Obj {
+            std::vector<at::IValue> iargs;
+            std::unordered_map<std::string, at::IValue> ikwargs;
+
+            for (auto& arg : args) {
+              iargs.emplace_back(toIValue(arg));
+            }
+            for (auto& arg : kwargs) {
+              ikwargs.emplace(
+                  arg.first.cast<std::string>(), toIValue(arg.second));
+            }
+
+            return self.callKwargs(iargs, ikwargs);
+          })
+      .def(
+          "__getattr__",
+          [](Obj& self, std::string attr) -> Obj {
+            return self.attr(attr.c_str());
+          })
+      .def("deref", [](Obj& self) -> py::object {
+        return ::torch::jit::toPyObject(detachIValue(self.toIValue()));
+      });
+}

--- a/multipy/runtime/test_pybind.py
+++ b/multipy/runtime/test_pybind.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+
+from multipy.runtime import InterpreterManager
+
+
+class TestPybind(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manager = InterpreterManager(1)
+
+    def test_print(self):
+        I = self.manager.acquire_one()
+        iprint = I.global_("builtins", "print")
+        iprint("hello!")
+
+    def test_tensor_passing(self):
+        I = self.manager.acquire_one()
+        model = I.global_("torch.nn", "Conv2d")(6, 2, 2, 1)
+        out = model(torch.ones((1, 6, 6, 6)))
+        tensor = out.deref()
+        self.assertIsInstance(tensor, torch.Tensor)
+        del out
+        del model
+        del I
+        print("exit2")
+
+    def test_multiple(self):
+        m = InterpreterManager(2)
+        self.assertEqual(len(m), 2)
+        for i in range(len(m)):
+            I = m[i]
+            iprint = I.global_("builtins", "print")
+            iprint(f"hello {i}")
+            del iprint
+            del I
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -265,6 +265,10 @@ if __name__ == "__main__":
                 "runtime/third-party/fmt/include/fmt/*",
                 "runtime/third-party/fmt/src/*",
                 "runtime/third-party/fmt/support/cmake/*",
+                "runtime/third-party/pybind11/*",
+                "runtime/third-party/pybind11/include/pybind11/*",
+                "runtime/third-party/pybind11/include/pybind11/detail/*",
+                "runtime/third-party/pybind11/tools/*",
             ]
         },
         data_files=[


### PR DESCRIPTION
This adds pybindings for multipy/runtime that are available at `multipy.runtime`. This creates a new `multipy_pybind.so` file in build/ with a bit of glue code from Python to load it correctly. Once landed this should be available in all normal deploy installs

This requires a few tricks:

* adds `-fPIC` to the multipy library so it can be included from a shared library
* modify custom loader to load symbols from the current library first (equivalent to RTLD_DEEPBIND) so local python symbols are preferred over the global python
* explicitly loads `libtorch.so` using RTLD_GLOBAL so libinterpreter.so has the symbols available

Current limitations:

* Obj must be destroyed/GCed before the InterpreterSession is destroyed. If left
    up to GC in most cases it will crash the program.
* No pickle interface for smartly transferring models between interpreters

Other cleanups:
* remove gtest from interpreter
* remove pytorch submodule dependency


Test plan:

Added test_pybind.py to the CI