### PR TITLE
multipy: relink against gtest

### DIFF
--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -80,5 +80,6 @@ target_include_directories(torch_deployinterpreter PRIVATE ${INTERPRETER_DIR})
 target_include_directories(torch_deployinterpreter BEFORE PUBLIC ${Python3_INCLUDE_DIRS})
 
 target_link_libraries(torch_deployinterpreter PRIVATE fmt::fmt-header-only)
+target_link_libraries(torch_deployinterpreter PRIVATE gtest)
 target_link_libraries(torch_deployinterpreter PRIVATE torch_python)
 target_link_libraries(torch_deployinterpreter PRIVATE multipy_torch)


### PR DESCRIPTION
Should fix regression in pytorch master https://hud.pytorch.org/minihud?name_filter=deploy

Test plan: CI

```
rm -r build; cmake -S . -B build; and cmake --build build/ --config Release -j -t multipy_pybind
```