### PR TITLE
Correct tag name of nightly release

### DIFF
--- a/.github/workflows/build_test_release.yaml
+++ b/.github/workflows/build_test_release.yaml
@@ -136,7 +136,7 @@ jobs:
       - name: Update nightly release
         uses: pyTooling/Actions/releaser@main
         with:
-          tag: multipy_runtime_python3.${{ inputs.python3-minor-version }}
+          tag: nightly-runtime-python3.${{ inputs.python3-minor-version }}
           rm: true
           token: ${{ secrets.token }}
           files: multipy_runtime_python3.${{ inputs.python3-minor-version }}.tar.gz

--- a/.github/workflows/runtime_nightly.yaml
+++ b/.github/workflows/runtime_nightly.yaml
@@ -1,7 +1,6 @@
 name: Multipy runtime nightly test + release
 
 on:
-  pull_request:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
   workflow_dispatch:

--- a/.github/workflows/runtime_nightly.yaml
+++ b/.github/workflows/runtime_nightly.yaml
@@ -1,6 +1,7 @@
 name: Multipy runtime nightly test + release
 
 on:
+  pull_request:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
   workflow_dispatch:


### PR DESCRIPTION
The latest nightly release failed due to an error with the tag name: https://github.com/pytorch/multipy/actions/runs/3717991399

This PR attempts to fix this.