### PR TITLE
Handle deprecation of `jobs=0` in git 2.39

### DIFF
--- a/.github/workflows/build_test_release.yaml
+++ b/.github/workflows/build_test_release.yaml
@@ -39,7 +39,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Sync git submodules"
-        git submodule update --init --recursive --jobs 0
+        git -c fetch.parallel=0 -c submodule.fetchJobs=0 submodule update --init --recursive
         echo "::endgroup::"
 
         echo "::group::Setup virtual environment"

--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -38,7 +38,7 @@ jobs:
           set -eux
           sudo apt update
           xargs sudo apt install -y -qq --no-install-recommends <build-requirements-debian.txt
-          git -c fetch.parallel=0 -c submodule.fetchJobs=0 submodule update --init --recursive 5k@63N7mmYeBs4K
+          git -c fetch.parallel=0 -c submodule.fetchJobs=0 submodule update --init --recursive
 
       - name: Update cmake
         run: |

--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -38,7 +38,7 @@ jobs:
           set -eux
           sudo apt update
           xargs sudo apt install -y -qq --no-install-recommends <build-requirements-debian.txt
-          git submodule update --init --recursive --jobs 0
+          git -c fetch.parallel=0 -c submodule.fetchJobs=0 submodule update --init --recursive 5k@63N7mmYeBs4K
 
       - name: Update cmake
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ COPY setup.py setup.py
 COPY README.md README.md
 COPY dev-requirements.txt dev-requirements.txt
 
-RUN git submodule update --init --recursive --jobs 0
+RUN git -c fetch.parallel=0 -c submodule.fetchJobs=0  submodule update --init --recursive
 
 # Install conda/pyenv + necessary python dependencies
 FROM dev-base as conda-pyenv


### PR DESCRIPTION
Currently CI jobs are failing because of a change introduced in https://github.com/git/git/commit/51243f9f0f6a932ea579fd6f8014b348f8c2a523. 

Example failing job: https://github.com/pytorch/multipy/actions/runs/3754393118/jobs/6381602585
Error message:
```
BUG: run-command.c:1521: you must provide a non-zero number of processes!
```

The git community recommends using the two flags set in this PR:
 - https://github.com/gitextensions/gitextensions/issues/10514
 - https://github.com/gitextensions/gitextensions/pull/10521