### PR TITLE
Explicitly run miniconda with `bash`

### DIFF
--- a/.github/workflows/install_test.yaml
+++ b/.github/workflows/install_test.yaml
@@ -127,7 +127,7 @@ jobs:
           if [[ ${{ matrix.python3-minor-version }} -gt 7 ]]; then \
           curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
           chmod +x ~/miniconda.sh && \
-          ~/miniconda.sh -b -p /opt/conda && \
+          /bin/bash ~/miniconda.sh -b -p /opt/conda && \
           rm ~/miniconda.sh && \
           /opt/conda/bin/conda install -y python=${{ env.python-version }} mkl mkl-include conda-build pyyaml numpy ipython && \
           /opt/conda/bin/conda install -y -c conda-forge libpython-static=${{ env.python-version }} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ ENV PYTHON_VERSION=3.${PYTHON_3_MINOR_VERSION}
 RUN if [[ ${PYTHON_3_MINOR_VERSION} -gt 7 ]]; then \
     curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
     chmod +x ~/miniconda.sh && \
-    ~/miniconda.sh -b -p /opt/conda && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
     rm ~/miniconda.sh && \
     /opt/conda/bin/conda install -y python=${PYTHON_VERSION} mkl mkl-include conda-build pyyaml numpy ipython && \
     /opt/conda/bin/conda install -y -c conda-forge libpython-static=${PYTHON_VERSION} && \

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Example commands for installing conda:
 ```shell
 curl -fsSL -v -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
 chmod +x ~/miniconda.sh && \
-~/miniconda.sh -b -p /opt/conda && \
+/bin/bash ~/miniconda.sh -b -p /opt/conda && \
 rm ~/miniconda.sh
 ```
 Virtualenv / pyenv can be installed as follows:


### PR DESCRIPTION
A change to the [Miniconda3-latest-Linux-x86_64.sh](https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh) has it use bash syntax - namely `[[ ]]` - while declaring a `#!/bin/sh` shebang.

With this PR I propose to explicitly run the miniconda executable using bash.