### PR TITLE
search recursively for static python

### DIFF
--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -20,22 +20,22 @@ message(STATUS "Python3_LIBRARIES - ${Python3_LIBRARIES}" )
 # libpython, as it's not guarenteed to be in the same directory as libpython such
 # as with pyenv.
 
-string(REPLACE ".so" ".nolto.a" Python3_STATIC_LIBRARIES ${Python3_LIBRARIES})
+FUNCTION(find_file_with_different_suffix VAR FILE ORIGINAL_SUFFIX NEW_SUFFIX)
+  string(REPLACE ${ORIGINAL_SUFFIX} ${NEW_SUFFIX} MODIFIED_FILE ${FILE})
 
-if (NOT EXISTS ${Python3_STATIC_LIBRARIES})
-  get_filename_component(STATIC_Python_FILENAME ${Python3_STATIC_LIBRARIES} NAME)
-  string(REPLACE "${STATIC_Python_FILENAME}" "**/${STATIC_Python_FILENAME}" STATIC_Python_GLOB ${Python3_STATIC_LIBRARIES} )
-  file(GLOB_RECURSE Python3_STATIC_LIBRARIES ${STATIC_Python_GLOB})
+  if (NOT EXISTS ${MODIFIED_FILE})
+    get_filename_component(MODIFIED_FILENAME ${MODIFIED_FILE} NAME)
+    string(REPLACE "${MODIFIED_FILENAME}" "**/${MODIFIED_FILENAME}" MODIFIED_FILE_GLOB ${MODIFIED_FILE} )
+    file(GLOB_RECURSE MODIFIED_FILE ${MODIFIED_FILE_GLOB})
 endif()
+set(${VAR} ${MODIFIED_FILE} PARENT_SCOPE)
+ENDFUNCTION()
+
+find_file_with_different_suffix(Python3_STATIC_LIBRARIES ${Python3_LIBRARIES} ".so" ".nolto.a")
+
 
 if (NOT EXISTS ${Python3_STATIC_LIBRARIES})
-  string(REPLACE ".so" ".a" Python3_STATIC_LIBRARIES ${Python3_LIBRARIES})
-endif()
-
-if (NOT EXISTS ${Python3_STATIC_LIBRARIES})
-  get_filename_component(STATIC_Python_FILENAME ${Python3_STATIC_LIBRARIES} NAME)
-  string(REPLACE "${STATIC_Python_FILENAME}" "**/${STATIC_Python_FILENAME}" STATIC_Python_GLOB ${Python3_STATIC_LIBRARIES})
-  file(GLOB_RECURSE Python3_STATIC_LIBRARIES ${STATIC_Python_GLOB})
+  find_file_with_different_suffix(Python3_STATIC_LIBRARIES ${Python3_LIBRARIES} ".so" ".a")
 endif()
 
 # If we still can't find the library, we fail early

--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -27,12 +27,11 @@ FUNCTION(find_file_with_different_suffix VAR FILE ORIGINAL_SUFFIX NEW_SUFFIX)
     get_filename_component(MODIFIED_FILENAME ${MODIFIED_FILE} NAME)
     string(REPLACE "${MODIFIED_FILENAME}" "**/${MODIFIED_FILENAME}" MODIFIED_FILE_GLOB ${MODIFIED_FILE} )
     file(GLOB_RECURSE MODIFIED_FILE ${MODIFIED_FILE_GLOB})
-endif()
-set(${VAR} ${MODIFIED_FILE} PARENT_SCOPE)
+  endif()
+  set(${VAR} ${MODIFIED_FILE} PARENT_SCOPE)
 ENDFUNCTION()
 
 find_file_with_different_suffix(Python3_STATIC_LIBRARIES ${Python3_LIBRARIES} ".so" ".nolto.a")
-
 
 if (NOT EXISTS ${Python3_STATIC_LIBRARIES})
   find_file_with_different_suffix(Python3_STATIC_LIBRARIES ${Python3_LIBRARIES} ".so" ".a")

--- a/multipy/runtime/interpreter/CMakeLists.txt
+++ b/multipy/runtime/interpreter/CMakeLists.txt
@@ -16,11 +16,36 @@ message(STATUS "Python3_SITELIB - ${Python3_SITELIB}" )
 message(STATUS "Python3_LIBRARIES - ${Python3_LIBRARIES}" )
 
 # Find static libpython with a preference for nolto since cross compiler version
-# LTO is problematic.
+# LTO is problematic. We also recursively search in the directory for static
+# libpython, as it's not guarenteed to be in the same directory as libpython such
+# as with pyenv.
+
 string(REPLACE ".so" ".nolto.a" Python3_STATIC_LIBRARIES ${Python3_LIBRARIES})
+
+if (NOT EXISTS ${Python3_STATIC_LIBRARIES})
+  get_filename_component(STATIC_Python_FILENAME ${Python3_STATIC_LIBRARIES} NAME)
+  string(REPLACE "${STATIC_Python_FILENAME}" "**/${STATIC_Python_FILENAME}" STATIC_Python_GLOB ${Python3_STATIC_LIBRARIES} )
+  file(GLOB_RECURSE Python3_STATIC_LIBRARIES ${STATIC_Python_GLOB})
+endif()
+
 if (NOT EXISTS ${Python3_STATIC_LIBRARIES})
   string(REPLACE ".so" ".a" Python3_STATIC_LIBRARIES ${Python3_LIBRARIES})
 endif()
+
+if (NOT EXISTS ${Python3_STATIC_LIBRARIES})
+  get_filename_component(STATIC_Python_FILENAME ${Python3_STATIC_LIBRARIES} NAME)
+  string(REPLACE "${STATIC_Python_FILENAME}" "**/${STATIC_Python_FILENAME}" STATIC_Python_GLOB ${Python3_STATIC_LIBRARIES})
+  file(GLOB_RECURSE Python3_STATIC_LIBRARIES ${STATIC_Python_GLOB})
+endif()
+
+# If we still can't find the library, we fail early
+if (NOT EXISTS ${Python3_STATIC_LIBRARIES})
+  get_filename_component(Python_FILENAME ${Python3_LIBRARIES} NAME)
+  string(REPLACE ".so" ".nolto.a" Python3_STATIC_NOLTO_FILENAME ${Python_FILENAME})
+  string(REPLACE ".so" ".a" Python3_STATIC_FILENAME ${Python_FILENAME})
+  message(FATAL_ERROR "Cannot find ${Python3_STATIC_NOLTO_FILENAME} or ${Python3_STATIC_FILENAME} in ${libpython_DIR}. Are you using a static version of python? Please refer to https://github.com/pytorch/multipy for install instructions using conda and pyenv.")
+endif()
+
 message(STATUS "Python3_STATIC_LIBRARIES - ${Python3_STATIC_LIBRARIES}" )
 
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/../..)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #294
* #293
* #292
* __->__ #290

Somehow our [install tests](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Fpytorch%2Fmultipy%2Factions%2Fruns%2F3788974361%2Fjobs%2F6444295267&h=AT1Oe4oLQF-3D7WRA3iOZ1WePW2BM1wIMWmAygwLrYJdWntwyd7IVYyOeO4E3-G0PpU2S9oqZjRf04QblCzQhaS4F82crzN1dKMjwZhaEvylo-jYZ2p5Mjwb2GEnU1VMuxQYn5AiHPEUaIotANfphERg9oY) and [runtime tests for python 3.7](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Fpytorch%2Fmultipy%2Factions%2Fruns%2F3788974394%2Fjobs%2F6444296064&h=AT1Oe4oLQF-3D7WRA3iOZ1WePW2BM1wIMWmAygwLrYJdWntwyd7IVYyOeO4E3-G0PpU2S9oqZjRf04QblCzQhaS4F82crzN1dKMjwZhaEvylo-jYZ2p5Mjwb2GEnU1VMuxQYn5AiHPEUaIotANfphERg9oY) are broken on main due to what appears to be a linking issue.
The root cause of these breakages ended up being that the static python library was moved a bit deeper into the directory we thought it would be in when using pyenv. We now search recursively for it, so that if it is there we are able to use it. Furthermore, we also fail early is we cannot find static python in order to help prevent future breakages.


Differential Revision: [D42272568](https://our.internmc.facebook.com/intern/diff/D42272568)