### PR TITLE
Back out "Convert multipy embedded library exceptions to specific exception type"

### DIFF
--- a/multipy/runtime/Exception.h
+++ b/multipy/runtime/Exception.h
@@ -4,13 +4,10 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
-#pragma once
-
 #ifndef MULTIPY_EXCEPTION_H
 #define MULTIPY_EXCEPTION_H
 
 #include <exception>
-#include <stdexcept>
 
 #define MULTIPY_INTERNAL_ASSERT_WITH_MESSAGE(condition, message)               \
   if (!(condition)) {                                                          \
@@ -54,13 +51,3 @@
       MULTIPY_CHECK_NO_MESSAGE(__VA_ARGS__));
 
 #endif // MULTIPY_EXCEPTION_H
-
-namespace torch {
-namespace deploy {
-class MultipyEmbeddedException : public std::runtime_error {
- public:
-  explicit MultipyEmbeddedException(const std::string& error)
-      : std::runtime_error(error) {}
-};
-} // namespace deploy
-} // namespace torch

--- a/multipy/runtime/interpreter/interpreter_impl.cpp
+++ b/multipy/runtime/interpreter/interpreter_impl.cpp
@@ -92,17 +92,17 @@ class MultiPySafeRethrow {
         auto code = err.value().attr("code").cast<int>();
         std::exit(code);
       }
-      throw torch::deploy::MultipyEmbeddedException(
+      throw std::runtime_error(
           std::string(file_) + ":" + std::to_string(line_) +
           ": Exception Caught inside torch::deploy embedded library: \n" +
           err.what());
     } catch (std::exception& err) {
-      throw torch::deploy::MultipyEmbeddedException(
+      throw std::runtime_error(
           std::string(file_) + ":" + std::to_string(line_) +
           ": Exception Caught inside torch::deploy embedded library: \n" +
           err.what());
     } catch (...) {
-      throw torch::deploy::MultipyEmbeddedException(
+      throw std::runtime_error(
           std::string(file_) + ":" + std::to_string(line_) +
           ": Unknown Exception Caught inside torch::deploy embedded library");
     }


### PR DESCRIPTION
Summary:
Original commit changeset: 9cb3d1f17f54

Original Phabricator Diff: D44477860

In deploy, we do dlopen to link the .so each time when we create interpreter. So when interpreter manager is out of scope, we dlclose so we no longer have any symbols in the interpreter .so lib https://fburl.com/code/wlcp3r9o.

If we throw a custom exception class that defined in interpreter .so, then in the catch block, if interpreter manager goes out of scope, we don't recognize this exception class anymore and lead to a crash.

Differential Revision: D45629261

