### PR TITLE
Disable pybind11's GIL checks

### DIFF
--- a/multipy/runtime/CMakeLists.txt
+++ b/multipy/runtime/CMakeLists.txt
@@ -9,12 +9,19 @@ project(MultipyRuntime)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# multipy currently does not pass pybind11's GIL checks.
+#
+# This usually indicates undefined behavior or a bug within extensions, but we don't have the resources to debug
+# this package right now.
+#
+# In the future, someone should find out why this code fails to work when these checks are enabled.
+add_definitions(-PYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF)
+
 
 # set ABI by default to 0
 
 option(BUILD_CUDA_TESTS "Set to ON in order to build cuda tests. By default we do not" OFF)
 option(GDB_ON "Sets to debug mode (for gdb), defaults to OFF" OFF)
-add_definitions(-DPYBIND11_NO_GIL_CHECKS)
 
 if(GDB_ON)
   set(CMAKE_BUILD_TYPE Debug)

--- a/multipy/runtime/CMakeLists.txt
+++ b/multipy/runtime/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_CUDA_TESTS "Set to ON in order to build cuda tests. By default we do not" OFF)
 option(GDB_ON "Sets to debug mode (for gdb), defaults to OFF" OFF)
+add_definitions(-PYBIND11_NO_GIL_CHECKS)
 
 if(GDB_ON)
   set(CMAKE_BUILD_TYPE Debug)

--- a/multipy/runtime/CMakeLists.txt
+++ b/multipy/runtime/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_CUDA_TESTS "Set to ON in order to build cuda tests. By default we do not" OFF)
 option(GDB_ON "Sets to debug mode (for gdb), defaults to OFF" OFF)
-add_definitions(-PYBIND11_NO_GIL_CHECKS)
+add_definitions(-DPYBIND11_NO_GIL_CHECKS)
 
 if(GDB_ON)
   set(CMAKE_BUILD_TYPE Debug)


### PR DESCRIPTION
pybind11 recently added a feature to assert that the GIL is held during reference counting operations https://github.com/pybind/pybind11/pull/4246

This feature has already uncovered several instances of undefined behavior in several Python extensions. 

However, this code does not seem to pass these checks, which is preventing us from upgrading PyTorch to the latest pybind11.

This PR disables those checks, which will in turn allow PyTorch to upgrade.

Note that this code already has known potential GIL issues: 

https://github.com/pytorch/multipy/blob/bd1c76f294335695db8bfa66250781c1627f4eb7/multipy/runtime/deploy.cpp#L59