### PR TITLE
Remove unused-variable in multipy/runtime/interpreter/interpreter_impl.cpp +1

### DIFF
--- a/multipy/runtime/interpreter/interpreter_impl.cpp
+++ b/multipy/runtime/interpreter/interpreter_impl.cpp
@@ -360,7 +360,6 @@ struct __attribute__((visibility("hidden"))) ConcreteInterpreterObj
 
   torch::deploy::Obj attr(const char* attribute) override {
     MULTIPY_SAFE_RETHROW {
-      bool a = hasattr(attribute);
       py::object pyObj = getPyObject().attr(attribute);
       std::shared_ptr<ConcreteInterpreterObj> cObj =
           std::make_shared<ConcreteInterpreterObj>(pyObj, owningSession_);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65282886


